### PR TITLE
Adds functions to Rewards Distributor Interface

### DIFF
--- a/src/RewardsDistributor.sol
+++ b/src/RewardsDistributor.sol
@@ -38,7 +38,7 @@ contract RewardsDistributor is Initializable, AccessControlUpgradeable, RewardsD
     //----------------------------------  VARIABLES  ---------------------------------------
     //--------------------------------------------------------------------------------------
 
-    IynETH ynETH;
+    IynETH public ynETH;
 
     /// @notice The contract receiving execution layer rewards, both tips and MEV rewards.
     RewardsReceiver public executionLayerReceiver;

--- a/src/interfaces/IRewardsDistributor.sol
+++ b/src/interfaces/IRewardsDistributor.sol
@@ -4,14 +4,37 @@ pragma solidity ^0.8.24;
 import {IRewardsReceiver} from "./IRewardsReceiver.sol";
 
 interface IRewardsDistributor {
+
+    /// @notice Returns the address of the ynETH token.
+    /// @return address of the ynETH token.
+    function ynETH() external view returns (address);
+
+    /// @notice Processes the rewards for the execution and consensus layer.
+    /// @dev This function should be called by off-chain rewards distribution service.
     function processRewards() external;
 
     /// @notice Returns the address of the execution layer rewards receiver.
-    /// @return The address of the execution layer rewards receiver.
+    /// @return address of the execution layer rewards receiver.
     function executionLayerReceiver() external view returns (IRewardsReceiver);
 
     /// @notice Returns the address of the consensus layer rewards receiver.
-    /// @return The address of the consensus layer rewards receiver.
+    /// @return address of the consensus layer rewards receiver.
     function consensusLayerReceiver() external view returns (IRewardsReceiver);
+
+    /// @notice Returns the address of the fees receiver.
+    /// @return address of the fees receiver.
+    function feesReceiver() external view returns (address);
+
+    /// @notice Returns the protocol fees in basis points (1/10000).
+    /// @return uint16 fees in basis points.
+    function feesBasisPoints() external view returns (uint16);
+
+    /// @notice Sets the address to receive protocol fees.
+    /// @param newReceiver The new fees receiver address.
+    function setFeesReceiver(address payable newReceiver) external;
+
+    /// @notice Sets the protocol fees in basis points (1/10000).
+    /// @param newFeesBasisPoints The new fees in basis points.
+    function setFeesBasisPoints(uint16 newFeesBasisPoints) external;
 }
 


### PR DESCRIPTION
Needed some view functions for testing so added functions from `RewardsDistributor.sol` to `IRewardsDistributor.sol`

Also, made the `ynETH` token state variable public on `RewardsDistributor.sol`