### PR TITLE
Fix Audit 6.12 redundant functionality

### DIFF
--- a/src/ynBase.sol
+++ b/src/ynBase.sol
@@ -131,14 +131,6 @@ contract ynBase is ERC20Upgradeable, AccessControlUpgradeable {
     }
 
     /**
-     * @dev Returns true if the address is whitelisted for transfers during pause, false otherwise.
-     */
-    function isAddressWhitelisted(address addr) public view returns (bool) {
-        ynBaseStorage storage $ = _getYnBaseStorage();
-        return $.pauseWhiteList[addr];
-    }
-
-    /**
      * @dev Returns true if the address is in the pause whitelist, false otherwise.
      */
     function pauseWhiteList(address addr) public view returns (bool) {

--- a/test/foundry/integration/ynLSD.t.sol
+++ b/test/foundry/integration/ynLSD.t.sol
@@ -503,7 +503,7 @@ contract ynLSDTransferPauseTest is IntegrationBaseTest {
         ynlsd.removeFromPauseWhitelist(whitelistAddresses); // Removing the EOA address from whitelist
 
         // Assert
-        bool isWhitelisted = ynlsd.isAddressWhitelisted(actors.TRANSFER_ENABLED_EOA);
+        bool isWhitelisted = ynlsd.pauseWhiteList(actors.TRANSFER_ENABLED_EOA);
         assertFalse(isWhitelisted, "EOA address was not removed from whitelist");
     }
 
@@ -522,8 +522,8 @@ contract ynLSDTransferPauseTest is IntegrationBaseTest {
         ynlsd.removeFromPauseWhitelist(newWhitelistAddresses); // Removing the new whitelist addresses
 
         // Assert
-        bool isFirstAddressWhitelisted = ynlsd.isAddressWhitelisted(newWhitelistAddresses[0]);
-        bool isSecondAddressWhitelisted = ynlsd.isAddressWhitelisted(newWhitelistAddresses[1]);
+        bool isFirstAddressWhitelisted = ynlsd.pauseWhiteList(newWhitelistAddresses[0]);
+        bool isSecondAddressWhitelisted = ynlsd.pauseWhiteList(newWhitelistAddresses[1]);
         assertFalse(isFirstAddressWhitelisted, "First new whitelist address was not removed");
         assertFalse(isSecondAddressWhitelisted, "Second new whitelist address was not removed");
     }


### PR DESCRIPTION
Removes the redundant function `ynBASE.isAddressWhitelisted.sol`
