### PR TITLE
Fix audit issue 6.2

### DIFF
--- a/src/LSDStakingNode.sol
+++ b/src/LSDStakingNode.sol
@@ -129,6 +129,14 @@ contract LSDStakingNode is ILSDStakingNode, Initializable, ReentrancyGuardUpgrad
         emit Undelegated(operator);
     }
 
+    /**
+     * @notice Recovers assets that were deposited directly
+     * @param asset The asset to be recovered
+     */
+    function recoverAssets(IERC20 asset) external onlyLSDRestakingManager {
+        asset.safeTransfer(address(ynLSD), asset.balanceOf(address(this)));
+    }
+
     //--------------------------------------------------------------------------------------
     //----------------------------------  MODIFIERS  ---------------------------------------
     //--------------------------------------------------------------------------------------

--- a/src/interfaces/ILSDStakingNode.sol
+++ b/src/interfaces/ILSDStakingNode.sol
@@ -30,4 +30,6 @@ interface ILSDStakingNode {
     function delegate(address operator) external;
 
     function undelegate() external;
+
+    function recoverAssets(IERC20 asset) external;
 }


### PR DESCRIPTION
This fixes audit issue 6.2 about `getTotalAssets()`

### Problem
`ynLSD.getTotalAssets()` counted the balance of `LSDStakingNode`, however assets directly held in LSDStakingNode were not recoverable. 

### Solution
Add a function to `LSDStakingNode` that can push an asset to `ynLSD`.