### PR TITLE
Fix deploy imports

### DIFF
--- a/script/BaseScript.s.sol
+++ b/script/BaseScript.s.sol
@@ -1,20 +1,17 @@
 // SPDX-License-Identifier: BSD 3-Clause License
 pragma solidity ^0.8.24;
 
-import "lib/openzeppelin-contracts/contracts/proxy/transparent/ProxyAdmin.sol";
-import "src/StakingNodesManager.sol";
-import "src/StakingNode.sol";
-import "src/RewardsReceiver.sol";
-import "src/ynLSD.sol";
-import "src/YieldNestOracle.sol";
-import "src/LSDStakingNode.sol";
-import "src/RewardsDistributor.sol";
-import "src/external/tokens/WETH.sol";
-import "src/ynETH.sol";
-import "lib/forge-std/src/Script.sol";
-import "lib/forge-std/src/StdJson.sol";
-import "script/Utils.sol";
-
+import {StakingNodesManager} from "src/StakingNodesManager.sol";
+import {StakingNode} from "src/StakingNode.sol";
+import {RewardsReceiver} from "src/RewardsReceiver.sol";
+import {ynLSD} from "src/ynLSD.sol";
+import {stdJson} from "lib/forge-std/src/StdJson.sol";
+import {YieldNestOracle} from "src/YieldNestOracle.sol";
+import {LSDStakingNode} from "src/LSDStakingNode.sol";
+import {RewardsDistributor} from "src/RewardsDistributor.sol";
+import {ynETH} from "src/ynETH.sol";
+import {Script} from "lib/forge-std/src/Script.sol";
+import {Utils} from "script/Utils.sol";
 import {ActorAddresses} from "script/Actors.sol";
 
 abstract contract BaseScript is Script, Utils {

--- a/script/ContractAddresses.sol
+++ b/script/ContractAddresses.sol
@@ -58,29 +58,6 @@ contract ContractAddresses {
             })
         });
 
-        addresses[5] = ChainAddresses({
-            ethereum: EthereumAddresses({
-                WETH_ADDRESS: 0xB4FBF271143F4FBf7B91A5ded31805e42b2208d6,
-                DEPOSIT_2_ADDRESS: 0xff50ed3d0ec03aC01D4C79aAd74928BFF48a7b2b
-            }),
-            eigenlayer: EigenlayerAddresses({
-                EIGENPOD_MANAGER_ADDRESS: 0xa286b84C96aF280a49Fe1F40B9627C2A2827df41,
-                DELEGATION_MANAGER_ADDRESS: 0x1b7b8F6b258f95Cf9596EabB9aa18B62940Eb0a8,
-                DELEGATION_PAUSER_ADDRESS: 0x369e6F597e22EaB55fFb173C6d9cD234BD699111,
-                STRATEGY_MANAGER_ADDRESS: 0x779d1b5315df083e3F9E94cB495983500bA8E907,
-                DELAYED_WITHDRAWAL_ROUTER_ADDRESS: 0x89581561f1F98584F88b0d57c2180fb89225388f
-            }),
-            lsd: LSDAddresses({
-                SFRXETH_ADDRESS: 0x0000000000000000000000000000000000000000,
-                RETH_ADDRESS: 0x178E141a0E3b34152f73Ff610437A7bf9B83267A,
-                STETH_ADDRESS: 0x1643E812aE58766192Cf7D2Cf9567dF2C37e9B7F,
-                RETH_FEED_ADDRESS: 0x9c18A124aB957578BE5AE04088159E4AAb22fAc3,
-                STETH_FEED_ADDRESS: 0x9c18A124aB957578BE5AE04088159E4AAb22fAc3,
-                RETH_STRATEGY_ADDRESS: 0x879944A8cB437a5f8061361f82A6d4EED59070b5,
-                STETH_STRATEGY_ADDRESS: 0xB613E78E2068d7489bb66419fB1cfa11275d14da
-            })
-        });
-
         // In absence of Eigenlayer a placeholder address is used for all Eigenlayer addresses
         address placeholderAddress = address(1);
 
@@ -111,5 +88,4 @@ contract ContractAddresses {
     function getChainAddresses(uint256 chainId) external view returns (ChainAddresses memory) {
         return addresses[chainId];
     }
-
 }

--- a/script/DeployYieldNest.s.sol
+++ b/script/DeployYieldNest.s.sol
@@ -2,22 +2,28 @@
 pragma solidity ^0.8.24;
 
 
-import "forge-std/Script.sol";
-import "lib/openzeppelin-contracts/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
-import "lib/openzeppelin-contracts/contracts/proxy/transparent/ProxyAdmin.sol";
-import "src/StakingNodesManager.sol";
-import "src/RewardsReceiver.sol";
-import "src/RewardsDistributor.sol";
-import "src/ynETH.sol";
-import "src/interfaces/IStakingNode.sol";
-import "src/external/ethereum/IDepositContract.sol";
-import "src/interfaces/IRewardsDistributor.sol";
-import "src/external/tokens/IWETH.sol";
-import "script/ContractAddresses.sol";
-import "script/BaseScript.s.sol";
-import "src/YieldNestOracle.sol";
-import "src/ynLSD.sol";
+import {TransparentUpgradeableProxy} from "lib/openzeppelin-contracts/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
+import {IEigenPodManager} from "src/external/eigenlayer/v0.1.0/interfaces/IEigenPodManager.sol";
+import {IDelegationManager} from "src/external/eigenlayer/v0.1.0/interfaces/IDelegationManager.sol";
+import {IDelayedWithdrawalRouter} from "src/external/eigenlayer/v0.1.0/interfaces/IDelayedWithdrawalRouter.sol";
+import {IStrategyManager} from "src/external/eigenlayer/v0.1.0/interfaces/IStrategyManager.sol";
+import {IDepositContract} from "src/external/ethereum/IDepositContract.sol";
+import {IRewardsDistributor} from "src/interfaces/IRewardsDistributor.sol";
+import {IynETH} from "src/interfaces/IynETH.sol";
+import {IStakingNodesManager} from "src/interfaces/IStakingNodesManager.sol";
+import {IWETH} from "src/external/tokens/IWETH.sol";
 
+import {StakingNodesManager} from "src/StakingNodesManager.sol";
+import {StakingNode} from "src/StakingNode.sol";
+import {RewardsReceiver} from "src/RewardsReceiver.sol";
+import {RewardsDistributor} from "src/RewardsDistributor.sol";
+import {ynETH} from "src/ynETH.sol";
+import {ContractAddresses} from "script/ContractAddresses.sol";
+import {BaseScript} from "script/BaseScript.s.sol";
+import {YieldNestOracle} from "src/YieldNestOracle.sol";
+import {ynLSD} from "src/ynLSD.sol";
+import {ActorAddresses} from "script/Actors.sol";
+import {console} from "lib/forge-std/src/console.sol";
 
 contract DeployYieldNest is BaseScript {
 

--- a/script/DeployYnLSD.s.sol
+++ b/script/DeployYnLSD.s.sol
@@ -2,13 +2,22 @@
 pragma solidity ^0.8.24;
 
 import {TransparentUpgradeableProxy} from "lib/openzeppelin-contracts/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
+import {IERC20} from "lib/openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
+import {IEigenPodManager} from "src/external/eigenlayer/v0.1.0/interfaces/IEigenPodManager.sol";
+import {IDelegationManager} from "src/external/eigenlayer/v0.1.0/interfaces/IDelegationManager.sol";
+import {IDelayedWithdrawalRouter} from "src/external/eigenlayer/v0.1.0/interfaces/IDelayedWithdrawalRouter.sol";
+import {IStrategyManager} from "src/external/eigenlayer/v0.1.0/interfaces/IStrategyManager.sol";
+import {IStrategy} from "src/external/eigenlayer/v0.1.0/interfaces/IStrategy.sol";
+import {IDepositContract} from "src/external/ethereum/IDepositContract.sol";
+import {IWETH} from "src/external/tokens/IWETH.sol";
+
 import {ynLSD} from "src/ynLSD.sol";
 import {YieldNestOracle} from "src/YieldNestOracle.sol";
 import {LSDStakingNode} from "src/LSDStakingNode.sol";
-import "src/external/tokens/IWETH.sol";
-import "script/ContractAddresses.sol";
-import "script/BaseScript.s.sol";
-
+import {ContractAddresses} from "script/ContractAddresses.sol";
+import {ActorAddresses} from "script/Actors.sol";
+import {BaseScript} from "script/BaseScript.s.sol";
+import {console} from "lib/forge-std/src/console.sol";
 
 contract DeployYnLSD is BaseScript {
     ynLSD public ynlsd;

--- a/script/Upgrade.s.sol
+++ b/script/Upgrade.s.sol
@@ -1,8 +1,14 @@
 // SPDX-License-Identifier: BSD 3-Clause License
 pragma solidity ^0.8.24;
 
-import "lib/openzeppelin-contracts/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
-import "script/BaseScript.s.sol";
+import {ITransparentUpgradeableProxy} from "lib/openzeppelin-contracts/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
+import {ProxyAdmin} from "lib/openzeppelin-contracts/contracts/proxy/transparent/ProxyAdmin.sol";
+import {BaseScript} from "script/BaseScript.s.sol";
+import {ynETH} from "src/ynETH.sol";
+import {StakingNodesManager} from "src/StakingNodesManager.sol";
+import {RewardsDistributor} from "src/RewardsDistributor.sol";
+import {StakingNode} from "src/StakingNode.sol";
+import {console} from "lib/forge-std/src/console.sol";
 
 contract Upgrade is BaseScript {
     function _deployImplementation(string memory contractName) internal returns (address, address) {
@@ -32,7 +38,6 @@ contract Upgrade is BaseScript {
         console.log("Upgrading contract with name:", contractName);
 
         uint256 deployerPrivateKey = vm.envUint("PRIVATE_KEY");
-        address _broadcaster = vm.addr(deployerPrivateKey);
         vm.startBroadcast(deployerPrivateKey);
 
         if (keccak256(bytes(contractName)) == keccak256("StakingNode")) {
@@ -45,7 +50,6 @@ contract Upgrade is BaseScript {
         (address proxyAddr, address implAddress) = _deployImplementation(contractName);
         vm.stopBroadcast();
         
-        ITransparentUpgradeableProxy proxy = ITransparentUpgradeableProxy(proxyAddr);
         console.log(string.concat(contractName, " address (proxy):"));
         console.log(proxyAddr);
         console.log("New implementation address:");

--- a/script/Utils.sol
+++ b/script/Utils.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BSD 3-Clause License
 pragma solidity ^0.8.24;
 
-import {Vm} from "forge-std/Vm.sol";
+import {Vm} from "lib/forge-std/src/Vm.sol";
 import {ERC1967Utils} from "lib/openzeppelin-contracts/contracts/proxy/ERC1967/ERC1967Utils.sol";
 
 contract Utils {


### PR DESCRIPTION
## Problem
After deploying and trying to verify contract on etherscan, I got an error stating the Bytecode onchain didn't match what was being verified. So I looked into the contract in the deploy scripts and noticed there were unused contracts being deployed from `import * "some-contract";` that were failing the etherscan verify script. 

## Changed to Alias imports
This allows granular control over which contracts are being imported and prevents unused imports.