### PR TITLE
fix ynEigenAdapter referral deposit

### DIFF
--- a/src/ynEIGEN/ynEigen.sol
+++ b/src/ynEIGEN/ynEigen.sol
@@ -12,7 +12,6 @@ import {ynBase} from "src/ynBase.sol";
 
 
 interface IynEigenEvents {
-    event Deposit(address indexed sender, address indexed receiver, uint256 amount, uint256 shares);
     event DepositAsset(address indexed sender, address indexed receiver, address indexed asset, uint256 amount, uint256 shares);
     event AssetRetrieved(IERC20 asset, uint256 amount, address destination);
     event LSDStakingNodeCreated(uint256 nodeId, address nodeAddress);

--- a/src/ynEIGEN/ynEigen.sol
+++ b/src/ynEIGEN/ynEigen.sol
@@ -13,6 +13,7 @@ import {ynBase} from "src/ynBase.sol";
 
 interface IynEigenEvents {
     event Deposit(address indexed sender, address indexed receiver, uint256 amount, uint256 shares);
+    event DepositAsset(address indexed sender, address indexed receiver, address indexed asset, uint256 amount, uint256 shares);
     event AssetRetrieved(IERC20 asset, uint256 amount, address destination);
     event LSDStakingNodeCreated(uint256 nodeId, address nodeAddress);
     event MaxNodeCountUpdated(uint256 maxNodeCount); 
@@ -150,7 +151,7 @@ contract ynEigen is IynEigen, ynBase, ReentrancyGuardUpgradeable, IynEigenEvents
 
         assets[address(asset)].balance += amount;        
 
-        emit Deposit(sender, receiver, amount, shares);
+        emit DepositAsset(sender, receiver, address(asset), amount, shares);
     }
 
     /**

--- a/src/ynEIGEN/ynEigenDepositAdapter.sol
+++ b/src/ynEIGEN/ynEigenDepositAdapter.sol
@@ -91,6 +91,8 @@ contract ynEigenDepositAdapter is IynEigenDepositAdapterEvents, Initializable, A
         } else if (address(asset) == address(oETH)) {
             return depositOETH(amount, receiver);
         } else {
+            asset.safeTransferFrom(msg.sender, address(this), amount);
+            asset.forceApprove(address(ynEigen), amount);
             return ynEigen.deposit(asset, amount, receiver);
         }
     }

--- a/src/ynEIGEN/ynEigenDepositAdapter.sol
+++ b/src/ynEIGEN/ynEigenDepositAdapter.sol
@@ -107,6 +107,12 @@ contract ynEigenDepositAdapter is IynEigenDepositAdapterEvents, Initializable, A
     }
 
 
+    /// @notice Simulates the deposit of assets into the ynEigen system and returns the expected number of shares.
+    /// @dev This function handles the conversion for oETH and stETH before simulating the deposit since
+    ///      they are not natively supported by ynEigen.
+    /// @param asset The asset to be deposited.
+    /// @param amount The amount of the asset to be deposited.
+    /// @return shares The expected number of ynEigen tokens (shares) to be received.
     function previewDeposit(IERC20 asset, uint256 amount) external view returns (uint256 shares) {
         if (address(asset) == address(oETH)) {
             // Convert oETH to woETH

--- a/src/ynEIGEN/ynEigenDepositAdapter.sol
+++ b/src/ynEIGEN/ynEigenDepositAdapter.sol
@@ -106,6 +106,22 @@ contract ynEigenDepositAdapter is IynEigenDepositAdapterEvents, Initializable, A
         }
     }
 
+
+    function previewDeposit(IERC20 asset, uint256 amount) external view returns (uint256 shares) {
+        if (address(asset) == address(oETH)) {
+            // Convert oETH to woETH
+            uint256 woETHAmount = IERC4626(woETH).convertToShares(amount);
+            return ynEigen.previewDeposit(IERC20(woETH), woETHAmount);
+        } else if (address(asset) == address(stETH)) {
+            // Convert stETH to wstETH
+            uint256 wstETHAmount = IwstETH(wstETH).getWstETHByStETH(amount);
+            return ynEigen.previewDeposit(IERC20(wstETH), wstETHAmount);
+        } else {
+            // For all other assets, use the standard previewDeposit function
+            return ynEigen.previewDeposit(IERC20(asset), amount);
+        }
+    }
+
     /**
      * @notice Deposits an asset with referral information.
      *          IMPORTANT: The referred or referree is the receiver, NOT msg.sender

--- a/test/integration/ynEIGEN/ynEigen.t.sol
+++ b/test/integration/ynEIGEN/ynEigen.t.sol
@@ -105,12 +105,12 @@ contract ynEigenTest is ynEigenIntegrationBaseTest {
     }
 
     function testDepositmETHSuccessWithOneDepositFuzz(
-        // uint256 amount
+        uint256 amount
      ) public {
-
-        uint256 amount = 2;
+        
+        // NOTE: mETH doesn't usually work with 10k amounts at a time to stake ETH and obtain it in 1 tx
         vm.assume(
-            amount < 10000 ether && amount >= 2 wei
+            amount < 1000 ether && amount >= 2 wei
         );        
 
         IERC20 mETH = IERC20(chainAddresses.lsd.METH_ADDRESS);

--- a/test/integration/ynEIGEN/ynEigenDepositAdapter.t.sol
+++ b/test/integration/ynEIGEN/ynEigenDepositAdapter.t.sol
@@ -30,7 +30,6 @@ contract ynEigenDepositAdapterTest is ynEigenIntegrationBaseTest {
         address receiver = address(0x456);
 
         // 1. Obtain wstETH and Deposit assets to ynEigen by User
-        TestAssetUtils testAssetUtils = new TestAssetUtils();
         testAssetUtils.get_stETH(depositor, depositAmount * 10);
 
         // Arrange: Setup the initial balance of stETH for the depositor
@@ -61,7 +60,6 @@ contract ynEigenDepositAdapterTest is ynEigenIntegrationBaseTest {
         address receiver = address(0xABC);
 
         // 1. Obtain woETH and Deposit assets to ynEigen by User
-        TestAssetUtils testAssetUtils = new TestAssetUtils();
         testAssetUtils.get_OETH(depositor, depositAmount * 10);
 
         // Arrange: Setup the initial balance of oETH for the depositor
@@ -139,7 +137,7 @@ contract ynEigenDepositAdapterTest is ynEigenIntegrationBaseTest {
 
         vm.startPrank(prankedUser);
         asset.approve(address(ynEigenDepositAdapterInstance), balance);
-        ynEigenDepositAdapterInstance.deposit(asset, balance, receiver);
+        uint256 shares = ynEigenDepositAdapterInstance.deposit(asset, balance, receiver);
         vm.stopPrank();
 
         uint256 finalAssetBalance = asset.balanceOf(address(ynEigenToken));
@@ -148,6 +146,11 @@ contract ynEigenDepositAdapterTest is ynEigenIntegrationBaseTest {
 
         // Verify asset balance of ynEigenToken increased
         assertEq(finalAssetBalance, initialAssetBalance + balance, "Asset balance did not increase correctly");
+        // Verify total supply increased
+        assertEq(finalSupply, initialSupply + shares, "Total supply did not increase correctly");
+
+        // Verify receiver balance increased
+        assertEq(finalReceiverBalance, initialReceiverBalance + shares, "Receiver balance did not increase correctly");
     }
     
     function testDepositWithReferralWstETHFuzz(
@@ -155,6 +158,7 @@ contract ynEigenDepositAdapterTest is ynEigenIntegrationBaseTest {
         address receiver,
         address referrer
     ) public {
+
         vm.assume(amount >= 2 wei && amount < 10000 ether);
         vm.assume(receiver != address(0) && referrer != address(0) && receiver != referrer);
 
@@ -186,5 +190,8 @@ contract ynEigenDepositAdapterTest is ynEigenIntegrationBaseTest {
         
         // Verify receiver balance increased
         assertEq(finalReceiverBalance, initialReceiverBalance + shares, "Receiver balance did not increase correctly");
+
+        // Verify user balance increased
+        assertEq(ynEigenToken.balanceOf(receiver), initialReceiverBalance + shares, "User balance did not increase correctly");
     }
 }

--- a/test/integration/ynEIGEN/ynEigenDepositAdapter.t.sol
+++ b/test/integration/ynEIGEN/ynEigenDepositAdapter.t.sol
@@ -12,6 +12,13 @@ import {ynBase} from "src/ynBase.sol";
 
 contract ynEigenDepositAdapterTest is ynEigenIntegrationBaseTest {
 
+
+    TestAssetUtils testAssetUtils;
+    constructor() {
+        testAssetUtils = new TestAssetUtils();
+    }
+
+
     function testDepositstETHSuccessWithOneDepositFuzz(
        uint256 depositAmount
     ) public {
@@ -72,5 +79,112 @@ contract ynEigenDepositAdapterTest is ynEigenIntegrationBaseTest {
             compareWithThreshold(receiverBalance, depositAmount, treshold),
             string.concat("Receiver's balance: ", vm.toString(receiverBalance), ", Expected balance: ", vm.toString(depositAmount))
         );
+    }
+
+    function testDepositwstETHSuccessWithOneDepositFuzzWithAdapter(
+        uint256 amount
+    ) public {
+        vm.assume(
+            amount < 10000 ether && amount >= 2 wei
+        );        
+
+        IERC20 wstETH = IERC20(chainAddresses.lsd.WSTETH_ADDRESS);
+        depositAssetAndVerify(wstETH, amount);
+    }
+
+    function testDepositsfrxETHSuccessWithOneDepositFuzzWithAdapter(
+        uint256 amount
+    ) public {
+        vm.assume(
+            amount < 10000 ether && amount >= 2 wei
+        );        
+
+        IERC20 sfrxETH = IERC20(chainAddresses.lsd.SFRXETH_ADDRESS);
+        depositAssetAndVerify(sfrxETH, amount);
+    }
+
+    function testDepositrETHSuccessWithOneDepositFuzzWithAdapter(
+        uint256 amount
+    ) public {
+        vm.assume(
+            amount < 10000 ether && amount >= 2 wei
+        );        
+
+        IERC20 rETH = IERC20(chainAddresses.lsd.RETH_ADDRESS);
+        depositAssetAndVerify(rETH, amount);
+    }
+
+    function testDepositmETHSuccessWithOneDepositFuzzWithAdapter(
+        uint256 amount
+     ) public {
+        // NOTE: mETH doesn't usually work with 10k amounts at a time to stake ETH and obtain it in 1 tx
+        vm.assume(
+            amount < 1000 ether && amount >= 2 wei
+        );        
+
+        IERC20 mETH = IERC20(chainAddresses.lsd.METH_ADDRESS);
+        depositAssetAndVerify(mETH, amount);
+    }
+
+    function depositAssetAndVerify(IERC20 asset, uint256 amount) internal {
+        address prankedUser = address(0x1234543210);
+        address receiver = address(0x9876543210);
+
+        uint256 initialSupply = ynEigenToken.totalSupply();
+        uint256 initialAssetBalance = asset.balanceOf(address(ynEigenToken));
+        uint256 initialReceiverBalance = ynEigenToken.balanceOf(receiver);
+
+        // Obtain asset for prankedUser
+        uint256 balance = testAssetUtils.get_Asset(address(asset), prankedUser, amount);
+
+        vm.startPrank(prankedUser);
+        asset.approve(address(ynEigenDepositAdapterInstance), balance);
+        ynEigenDepositAdapterInstance.deposit(asset, balance, receiver);
+        vm.stopPrank();
+
+        uint256 finalAssetBalance = asset.balanceOf(address(ynEigenToken));
+        uint256 finalSupply = ynEigenToken.totalSupply();
+        uint256 finalReceiverBalance = ynEigenToken.balanceOf(receiver);
+
+        // Verify asset balance of ynEigenToken increased
+        assertEq(finalAssetBalance, initialAssetBalance + balance, "Asset balance did not increase correctly");
+    }
+    
+    function testDepositWithReferralWstETHFuzz(
+        uint256 amount,
+        address receiver,
+        address referrer
+    ) public {
+        vm.assume(amount >= 2 wei && amount < 10000 ether);
+        vm.assume(receiver != address(0) && referrer != address(0) && receiver != referrer);
+
+        address prankedUser = address(0x1234543210);
+        IERC20 wstETH = IERC20(chainAddresses.lsd.WSTETH_ADDRESS);
+
+        uint256 initialSupply = ynEigenToken.totalSupply();
+        uint256 initialAssetBalance = wstETH.balanceOf(address(ynEigenToken));
+        uint256 initialReceiverBalance = ynEigenToken.balanceOf(receiver);
+
+        // Obtain asset for prankedUser
+        uint256 balance = testAssetUtils.get_Asset(address(wstETH), prankedUser, amount);
+
+        vm.startPrank(prankedUser);
+        wstETH.approve(address(ynEigenDepositAdapterInstance), balance);
+        
+        uint256 shares = ynEigenDepositAdapterInstance.depositWithReferral(wstETH, balance, receiver, referrer);
+        vm.stopPrank();
+
+        uint256 finalAssetBalance = ynEigenToken.assetBalance(wstETH);
+        uint256 finalSupply = ynEigenToken.totalSupply();
+        uint256 finalReceiverBalance = ynEigenToken.balanceOf(receiver);
+
+        // Verify wstETH balance of ynEigenToken increased
+        assertEq(finalAssetBalance, initialAssetBalance + balance, "wstETH balance did not increase correctly");
+        
+        // Verify total supply increased
+        assertEq(finalSupply, initialSupply + shares, "Total supply did not increase correctly");
+        
+        // Verify receiver balance increased
+        assertEq(finalReceiverBalance, initialReceiverBalance + shares, "Receiver balance did not increase correctly");
     }
 }


### PR DESCRIPTION
Context:

Number 1:

ynEigenDepositAdapter bug - 

for all assets except stETH and oETH

the `ynEigenDepositAdapter.deposit` function does simply:

            return ynEigen.deposit(asset, amount, receiver);
            
            instead of:

            asset.safeTransferFrom(msg.sender, address(this), amount);
            asset.forceApprove(address(ynEigen), amount);
            return ynEigen.deposit(asset, amount, receiver);
            
            Which does not actually transfer tokens over.


            
This fix fixes this function and its caller.

Additionally added a previewDeposit that handles all assets for convenience.

Number 2:

the asset parameter was left out from the deposit event in ynEigen, which makes it difficult to capture the info easily of what deposit was made.

Context still exists from the asset that was transferred but it's not contained properly in the event