### PR TITLE
Make TestAssetUtils work on holesky

### DIFF
--- a/src/external/frax/IfrxETH.sol
+++ b/src/external/frax/IfrxETH.sol
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: BSD 3-Clause License
+pragma solidity ^0.8.24;
+
+import {IERC4626} from "lib/openzeppelin-contracts/contracts/interfaces/IERC4626.sol";
+
+interface IfrxETH is IERC4626 {
+    function minters_array(uint256) external view returns (address);
+}

--- a/src/external/lido/IstETH.sol
+++ b/src/external/lido/IstETH.sol
@@ -5,4 +5,5 @@ import {IERC20} from  "lib/openzeppelin-contracts/contracts/token/ERC20/IERC20.s
 
 interface IstETH is IERC20 {
     function getPooledEthByShares(uint256 _shares) external view returns (uint256);
+    function getCurrentStakeLimit() external view returns (uint256);
 }

--- a/src/external/mantle/ImETH.sol
+++ b/src/external/mantle/ImETH.sol
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: BSD 3-Clause License
+pragma solidity ^0.8.24;
+
+import {IERC20} from  "lib/openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
+
+interface ImETH is IERC20 {
+    function stakingContract() external view returns (address);
+}

--- a/test/integration/ynEIGEN/ynEigen.t.sol
+++ b/test/integration/ynEIGEN/ynEigen.t.sol
@@ -9,6 +9,7 @@ import {IERC20} from "lib/openzeppelin-contracts/contracts/token/ERC20/IERC20.so
 import {IPausable} from "lib/eigenlayer-contracts/src/contracts/interfaces//IPausable.sol";
 import {ITokenStakingNode} from "src/interfaces/ITokenStakingNode.sol";
 import {ynBase} from "src/ynBase.sol";
+import {IstETH} from "src/external/lido/IstETH.sol";
 
 contract ynEigenTest is ynEigenIntegrationBaseTest {
 
@@ -81,6 +82,13 @@ contract ynEigenTest is ynEigenIntegrationBaseTest {
         vm.assume(
             amount < 10000 ether && amount >= 2 wei
         );
+        
+        {
+        // we need this to prevent revert: SAKE_LIMIT
+            uint256 stakeLimit = IstETH(chainAddresses.lsd.STETH_ADDRESS).getCurrentStakeLimit();
+            uint256 stETHToMint = amount * IwstETH(chainAddresses.lsd.WSTETH_ADDRESS).stEthPerToken() / 1e18 + 1 ether;
+            vm.assume(stETHToMint <= stakeLimit);
+        }
 
         IERC20 wstETH = IERC20(chainAddresses.lsd.WSTETH_ADDRESS);
         depositAssetAndVerify(wstETH, amount);
@@ -118,27 +126,38 @@ contract ynEigenTest is ynEigenIntegrationBaseTest {
     }
 
     function testMultipleDepositsFuzz(
-        uint8 asset0Index,
-        uint8 asset1Index,
         uint256 asset0Amount,
-        uint256 asset1Amount
+        uint256 asset1Amount,
+        uint256 asset2Amount,
+        uint256 asset3Amount
         ) public {
-
-        vm.assume(asset0Index < 4 && asset1Index < 4);
         vm.assume(
             asset0Amount < 10000 ether && asset0Amount >= 2 wei &&
-            asset1Amount < 10000 ether && asset1Amount >= 2 wei
+            asset1Amount < 10000 ether && asset1Amount >= 2 wei &&
+            asset2Amount < 10000 ether && asset2Amount >= 2 wei &&
+            asset3Amount < 10000 ether && asset3Amount >= 2 wei
         );
 
-        IERC20[] memory assets = new IERC20[](4);
-        assets[0] = IERC20(chainAddresses.lsd.WSTETH_ADDRESS);
-        assets[1] = IERC20(chainAddresses.lsd.SFRXETH_ADDRESS);
-        assets[2] = IERC20(chainAddresses.lsd.RETH_ADDRESS);
-        assets[3] = IERC20(chainAddresses.lsd.WOETH_ADDRESS);
+        {
+            // we need this to prevent revert: SAKE_LIMIT
+            uint256 stakeLimit = IstETH(chainAddresses.lsd.STETH_ADDRESS).getCurrentStakeLimit();
+            uint256 stETHToMint = asset0Amount * IwstETH(chainAddresses.lsd.WSTETH_ADDRESS).stEthPerToken() / 1e18 + 1 ether;
+            vm.assume(stETHToMint <= stakeLimit);
+        }
 
-        depositAssetAndVerify(assets[asset0Index], asset0Amount);
-        depositAssetAndVerify(assets[asset1Index], asset1Amount);
+        IERC20[] memory _assets = new IERC20[](4);
+        _assets[0] = IERC20(chainAddresses.lsd.WSTETH_ADDRESS);
+        _assets[1] = IERC20(chainAddresses.lsd.SFRXETH_ADDRESS);
+        _assets[2] = IERC20(chainAddresses.lsd.RETH_ADDRESS);
+        _assets[3] = IERC20(chainAddresses.lsd.WOETH_ADDRESS);
 
+        depositAssetAndVerify(_assets[0], asset0Amount);
+        depositAssetAndVerify(_assets[1], asset1Amount);
+        depositAssetAndVerify(_assets[2], asset2Amount);
+
+        if (!_isHolesky()) {
+            depositAssetAndVerify(_assets[3], asset3Amount);
+        }
     }
 
     function testDepositwstETHSuccessWithMultipleDeposits() public {

--- a/test/integration/ynEIGEN/ynEigen.t.sol
+++ b/test/integration/ynEIGEN/ynEigen.t.sol
@@ -9,7 +9,6 @@ import {IERC20} from "lib/openzeppelin-contracts/contracts/token/ERC20/IERC20.so
 import {IPausable} from "lib/eigenlayer-contracts/src/contracts/interfaces//IPausable.sol";
 import {ITokenStakingNode} from "src/interfaces/ITokenStakingNode.sol";
 import {ynBase} from "src/ynBase.sol";
-import {IstETH} from "src/external/lido/IstETH.sol";
 
 contract ynEigenTest is ynEigenIntegrationBaseTest {
 
@@ -83,12 +82,7 @@ contract ynEigenTest is ynEigenIntegrationBaseTest {
             amount < 10000 ether && amount >= 2 wei
         );
         
-        {
-        // we need this to prevent revert: SAKE_LIMIT
-            uint256 stakeLimit = IstETH(chainAddresses.lsd.STETH_ADDRESS).getCurrentStakeLimit();
-            uint256 stETHToMint = amount * IwstETH(chainAddresses.lsd.WSTETH_ADDRESS).stEthPerToken() / 1e18 + 1 ether;
-            vm.assume(stETHToMint <= stakeLimit);
-        }
+        testAssetUtils.assumeEnoughStakeLimit(amount);
 
         IERC20 wstETH = IERC20(chainAddresses.lsd.WSTETH_ADDRESS);
         depositAssetAndVerify(wstETH, amount);
@@ -138,12 +132,7 @@ contract ynEigenTest is ynEigenIntegrationBaseTest {
             asset3Amount < 10000 ether && asset3Amount >= 2 wei
         );
 
-        {
-            // we need this to prevent revert: SAKE_LIMIT
-            uint256 stakeLimit = IstETH(chainAddresses.lsd.STETH_ADDRESS).getCurrentStakeLimit();
-            uint256 stETHToMint = asset0Amount * IwstETH(chainAddresses.lsd.WSTETH_ADDRESS).stEthPerToken() / 1e18 + 1 ether;
-            vm.assume(stETHToMint <= stakeLimit);
-        }
+        testAssetUtils.assumeEnoughStakeLimit(asset0Amount);
 
         IERC20[] memory _assets = new IERC20[](4);
         _assets[0] = IERC20(chainAddresses.lsd.WSTETH_ADDRESS);

--- a/test/integration/ynEIGEN/ynEigenDepositAdapter.t.sol
+++ b/test/integration/ynEIGEN/ynEigenDepositAdapter.t.sol
@@ -9,7 +9,6 @@ import {IERC20} from "lib/openzeppelin-contracts/contracts/token/ERC20/IERC20.so
 import {IPausable} from "lib/eigenlayer-contracts/src/contracts/interfaces//IPausable.sol";
 import {ITokenStakingNode} from "src/interfaces/ITokenStakingNode.sol";
 import {ynBase} from "src/ynBase.sol";
-import {IstETH} from "src/external/lido/IstETH.sol";
 
 contract ynEigenDepositAdapterTest is ynEigenIntegrationBaseTest {
 
@@ -123,13 +122,8 @@ contract ynEigenDepositAdapterTest is ynEigenIntegrationBaseTest {
         vm.assume(
             amount < 10000 ether && amount >= 2 wei
         );
-        
-        {
-        // we need this to prevent revert: SAKE_LIMIT
-            uint256 stakeLimit = IstETH(chainAddresses.lsd.STETH_ADDRESS).getCurrentStakeLimit();
-            uint256 stETHToMint = amount * IwstETH(chainAddresses.lsd.WSTETH_ADDRESS).stEthPerToken() / 1e18 + 1 ether;
-            vm.assume(stETHToMint <= stakeLimit);
-        }
+
+        testAssetUtils.assumeEnoughStakeLimit(amount);
 
         IERC20 wstETH = IERC20(chainAddresses.lsd.WSTETH_ADDRESS);
         depositAssetAndVerify(wstETH, amount);
@@ -210,12 +204,7 @@ contract ynEigenDepositAdapterTest is ynEigenIntegrationBaseTest {
     ) public {
         vm.assume(amount >= 2 wei && amount < 10000 ether);
 
-        {
-        // we need this to prevent revert: SAKE_LIMIT
-            uint256 stakeLimit = IstETH(chainAddresses.lsd.STETH_ADDRESS).getCurrentStakeLimit();
-            uint256 stETHToMint = amount * IwstETH(chainAddresses.lsd.WSTETH_ADDRESS).stEthPerToken() / 1e18 + 1 ether;
-            vm.assume(stETHToMint <= stakeLimit);
-        }
+        testAssetUtils.assumeEnoughStakeLimit(amount);
 
         vm.assume(receiver != address(0) && referrer != address(0) && receiver != referrer);
 

--- a/test/integration/ynEIGEN/ynEigenDepositAdapter.t.sol
+++ b/test/integration/ynEIGEN/ynEigenDepositAdapter.t.sol
@@ -9,6 +9,7 @@ import {IERC20} from "lib/openzeppelin-contracts/contracts/token/ERC20/IERC20.so
 import {IPausable} from "lib/eigenlayer-contracts/src/contracts/interfaces//IPausable.sol";
 import {ITokenStakingNode} from "src/interfaces/ITokenStakingNode.sol";
 import {ynBase} from "src/ynBase.sol";
+import {IstETH} from "src/external/lido/IstETH.sol";
 
 contract ynEigenDepositAdapterTest is ynEigenIntegrationBaseTest {
 
@@ -122,6 +123,13 @@ contract ynEigenDepositAdapterTest is ynEigenIntegrationBaseTest {
         vm.assume(
             amount < 10000 ether && amount >= 2 wei
         );
+        
+        {
+        // we need this to prevent revert: SAKE_LIMIT
+            uint256 stakeLimit = IstETH(chainAddresses.lsd.STETH_ADDRESS).getCurrentStakeLimit();
+            uint256 stETHToMint = amount * IwstETH(chainAddresses.lsd.WSTETH_ADDRESS).stEthPerToken() / 1e18 + 1 ether;
+            vm.assume(stETHToMint <= stakeLimit);
+        }
 
         IERC20 wstETH = IERC20(chainAddresses.lsd.WSTETH_ADDRESS);
         depositAssetAndVerify(wstETH, amount);
@@ -200,8 +208,15 @@ contract ynEigenDepositAdapterTest is ynEigenIntegrationBaseTest {
         address receiver,
         address referrer
     ) public {
-
         vm.assume(amount >= 2 wei && amount < 10000 ether);
+
+        {
+        // we need this to prevent revert: SAKE_LIMIT
+            uint256 stakeLimit = IstETH(chainAddresses.lsd.STETH_ADDRESS).getCurrentStakeLimit();
+            uint256 stETHToMint = amount * IwstETH(chainAddresses.lsd.WSTETH_ADDRESS).stEthPerToken() / 1e18 + 1 ether;
+            vm.assume(stETHToMint <= stakeLimit);
+        }
+
         vm.assume(receiver != address(0) && referrer != address(0) && receiver != referrer);
 
         address prankedUser = address(0x1234543210);

--- a/test/utils/TestAssetUtils.sol
+++ b/test/utils/TestAssetUtils.sol
@@ -12,6 +12,7 @@ import { ImETH } from "src/external/mantle/ImETH.sol";
 import {IrETH} from "src/external/rocketpool/IrETH.sol";
 import { IynEigen } from "src/interfaces/IynEigen.sol";
 import { ImETHStaking } from "src/external/mantle/ImETHStaking.sol";
+import {IstETH} from "src/external/lido/IstETH.sol";
 
 import "forge-std/console.sol";
 
@@ -96,6 +97,13 @@ contract TestAssetUtils is Test {
         wsteth.transfer(receiver, amount);
 
         return amount;
+    }
+
+    // this can be used for preventing revert: STAKE_LIMIT
+    function assumeEnoughStakeLimit(uint256 amount) public {
+        uint256 stakeLimit = IstETH(chainAddresses.lsd.STETH_ADDRESS).getCurrentStakeLimit();
+        uint256 stETHToMint = amount * IwstETH(chainAddresses.lsd.WSTETH_ADDRESS).stEthPerToken() / 1e18 + 1 ether;
+        vm.assume(stETHToMint <= stakeLimit);
     }
 
     function get_OETH(address receiver, uint256 amount) public returns (uint256) {

--- a/test/utils/TestAssetUtils.sol
+++ b/test/utils/TestAssetUtils.sol
@@ -7,6 +7,8 @@ import {ContractAddresses} from "script/ContractAddresses.sol";
 import {IwstETH} from "src/external/lido/IwstETH.sol";
 import {IERC4626} from "lib/openzeppelin-contracts/contracts/interfaces/IERC4626.sol";
 import { IfrxMinter } from "src/external/frax/IfrxMinter.sol";
+import { IfrxETH } from "src/external/frax/IfrxETH.sol";
+import { ImETH } from "src/external/mantle/ImETH.sol";
 import {IrETH} from "src/external/rocketpool/IrETH.sol";
 import { IynEigen } from "src/interfaces/IynEigen.sol";
 import { ImETHStaking } from "src/external/mantle/ImETHStaking.sol";
@@ -16,6 +18,7 @@ import "forge-std/console.sol";
 interface IRocketPoolDepositPool {
     function deposit() external payable;
 }
+
 
 contract TestAssetUtils is Test {
 
@@ -166,10 +169,11 @@ contract TestAssetUtils is Test {
 
         IERC20 sfrxETH = IERC20(chainAddresses.lsd.SFRXETH_ADDRESS);
         IERC4626 sfrxETHVault = IERC4626(chainAddresses.lsd.SFRXETH_ADDRESS);
+        IfrxETH frxETH = IfrxETH(sfrxETHVault.asset());
 
         uint256 rate = sfrxETHVault.totalAssets() * 1e18 / sfrxETHVault.totalSupply();
 
-        IfrxMinter frxMinter = IfrxMinter(0xbAFA44EFE7901E04E39Dad13167D089C559c1138);
+        IfrxMinter frxMinter = IfrxMinter(frxETH.minters_array(0));
         uint256 ethToDeposit = amount * rate / 1e18 + 1 ether;
         vm.deal(address(this), ethToDeposit);
         frxMinter.submitAndDeposit{value: ethToDeposit}(address(this));
@@ -182,7 +186,7 @@ contract TestAssetUtils is Test {
     }
 
     function get_mETH(address receiver, uint256 amount) public returns (uint256) {
-        ImETHStaking mETHStaking = ImETHStaking(0xe3cBd06D7dadB3F4e6557bAb7EdD924CD1489E8f);
+        ImETHStaking mETHStaking = ImETHStaking(ImETH(chainAddresses.lsd.METH_ADDRESS).stakingContract());
         IERC20 mETH = IERC20(chainAddresses.lsd.METH_ADDRESS);
 
         uint256 ethRequired = mETHStaking.mETHToETH(amount) + 1 ether;


### PR DESCRIPTION
This PR changes the way some of the tokens are being created on `TestAssetUtils` which were failing on Holesky
The changes were made based the following test fails, but it fixes some others too:
```
Encountered 4 failing tests in test/integration/ynEIGEN/ynEigenDepositAdapter.t.sol:ynEigenDepositAdapterTest
[FAIL: revert: ETH transfer failed; counterexample: calldata=0xc1183df400000000000000000000000000000000000000000000020fc73d857eef32e659000000000000000000000000fecb0087ff8f2f84da5029801203f63e3dc96ee2000000000000000000000000ccb1d3728f822d2443d4ebdcc340f68b3b53941e args=[9735790904812286174809 [9.735e21], 0xFecB0087Ff8F2F84dA5029801203F63E3Dc96ee2, 0xCcb1d3728F822d2443d4EBDCC340f68B3b53941E]] testDepositWithReferralWstETHFuzz(uint256,address,address) (runs: 3, μ: 678461, ~: 678461)
[FAIL: EvmError: Revert; counterexample: calldata=0xb730072a000000000000000000000000000000000000000000000000000000003aa7bfa7 args=[984072103 [9.84e8]]] testDepositmETHSuccessWithOneDepositFuzzWithAdapter(uint256) (runs: 0, μ: 0, ~: 0)
[FAIL: EvmError: Revert; counterexample: calldata=0xd1f71fb0000000000000000000000000000000000000000000000000000000003aa7bfa7 args=[984072103 [9.84e8]]] testDepositsfrxETHSuccessWithOneDepositFuzzWithAdapter(uint256) (runs: 0, μ: 0, ~: 0)
[FAIL: revert: ETH transfer failed; counterexample: calldata=0x5327de7800000000000000000000000000000000000000000000020fc73d857eef32e659 args=[9735790904812286174809 [9.735e21]]] testDepositwstETHSuccessWithOneDepositFuzzWithAdapter(uint256) (runs: 3, μ: 778273, ~: 778273)
```

```
Encountered 2 failing tests in test/integration/ynEIGEN/ynEigen.t.sol:ynEigenTest
[FAIL: revert: ETH transfer failed; counterexample: calldata=0xa924fdcf00000000000000000000000000000000000000000000020fc73d857eef32e659 args=[9735790904812286174809 [9.735e21]]] testDepositwstETHSuccessWithOneDepositFuzz(uint256) (runs: 3, μ: 839625, ~: 839625)
[FAIL: revert: ETH transfer failed; counterexample: calldata=0x2e6872f00000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000af88e7bd81d0000000000000000000000000000000000000000000000b6bcbc2d633afd0faf args=[1, 0, 12062658648093 [1.206e13], 3370907216294105124783 [3.37e21]]] testMultipleDepositsFuzz(uint8,uint8,uint256,uint256) (runs: 1, μ: 1166511, ~: 1166511)
```