### PR TITLE
Fix TokenStakingNodeTest failing tests

### DIFF
--- a/test/integration/ynEIGEN/TokenStakingNode.t.sol
+++ b/test/integration/ynEIGEN/TokenStakingNode.t.sol
@@ -51,9 +51,10 @@ contract NodeStateSnapshot {
     
     bool public isHolesky;
     constructor() {
-        isHolesky = block.chainid == 17000;
         contractAddresses = new ContractAddresses();
         chainAddresses = contractAddresses.getChainAddresses(block.chainid);
+        (, uint256 holeskyId) = contractAddresses.chainIds();
+        isHolesky = block.chainid == holeskyId;
     }
 
     function takeSnapshot(address testAddress, uint256 nodeId) external {

--- a/test/integration/ynEIGEN/TokenStakingNode.t.sol
+++ b/test/integration/ynEIGEN/TokenStakingNode.t.sol
@@ -14,7 +14,7 @@ import {IwstETH} from "src/external/lido/IwstETH.sol";
 import {EigenStrategyManager} from "src/ynEIGEN/EigenStrategyManager.sol";
 import {IAssetRegistry} from "src/interfaces/IAssetRegistry.sol";
 import {IStrategy} from "lib/eigenlayer-contracts/src/contracts/interfaces/IStrategy.sol";
-
+import {ContractAddresses} from "script/ContractAddresses.sol";
 
 
 import "forge-std/console.sol";
@@ -46,8 +46,15 @@ struct StateSnapshot {
 
 contract NodeStateSnapshot {
     StateSnapshot public snapshot;
-
-    constructor() {}
+    ContractAddresses public contractAddresses;
+    ContractAddresses.ChainAddresses public chainAddresses;
+    
+    bool public isHolesky;
+    constructor() {
+        isHolesky = block.chainid == 17000;
+        contractAddresses = new ContractAddresses();
+        chainAddresses = contractAddresses.getChainAddresses(block.chainid);
+    }
 
     function takeSnapshot(address testAddress, uint256 nodeId) external {
 
@@ -60,6 +67,13 @@ contract NodeStateSnapshot {
         IERC20[] memory assets = state.assetRegistry().getAssets();
 
         for (uint256 i = 0; i < assets.length; i++) {
+            if (isHolesky && (
+                address(assets[i]) == chainAddresses.lsd.OETH_ADDRESS ||
+                address(assets[i]) == chainAddresses.lsd.WOETH_ADDRESS ||
+                address(assets[i]) == chainAddresses.lsd.SWELL_ADDRESS
+            ) ) {
+                continue;
+            }
             IERC20 asset = assets[i];
             IStrategy strategy = state.eigenStrategyManager().strategies(asset);
 
@@ -138,6 +152,8 @@ contract TokenStakingNodeTest is ynEigenIntegrationBaseTest {
         vm.assume(
             wstethAmount < 10000 ether && wstethAmount >= 2 wei
         );
+        
+        testAssetUtils.assumeEnoughStakeLimit(wstethAmount);
 
 		// 1. Obtain wstETH and Deposit assets to ynEigen by User
         IERC20 wstETH = IERC20(chainAddresses.lsd.WSTETH_ADDRESS);
@@ -190,7 +206,7 @@ contract TokenStakingNodeTest is ynEigenIntegrationBaseTest {
 		uint256[] memory amounts = new uint256[](1);
 		amounts[0] = balance;
 		vm.prank(actors.ops.STRATEGY_CONTROLLER);
-		vm.expectRevert("Pausable: index is paused");
+		vm.expectRevert(IPausable.CurrentlyPaused.selector);
 		eigenStrategyManager.stakeAssetsToNode(nodeId, assets, amounts);
 	}
 


### PR DESCRIPTION
This PR fixes some failing tests in TokenStakingNodeTest.
```
Encountered 4 failing tests in test/integration/ynEIGEN/TokenStakingNode.t.sol:TokenStakingNodeTest
[FAIL: Error != expected error: CurrentlyPaused() != Pausable: index is paused] testDepositAssetsToEigenlayerFail() (gas: 1043397)
[FAIL: revert: ETH transfer failed; counterexample: calldata=0xfc882e9200000000000000000000000000000000000000000000020fc73d857eef32e659 args=[9735790904812286174809 [9.735e21]]] testDepositAssetsToEigenlayerSuccessFuzz(uint256) (runs: 3, μ: 1058319, ~: 1058319)
[FAIL: EvmError: Revert] testQueueAndCompleteWithdrawals() (gas: 2535549)
[FAIL: EvmError: Revert] testTokenQueueWithdrawals() (gas: 2159314)
```