### PR TITLE
fix: Use new variable to prevent new initialization

### DIFF
--- a/src/interfaces/ITokenStakingNode.sol
+++ b/src/interfaces/ITokenStakingNode.sol
@@ -20,8 +20,6 @@ interface ITokenStakingNode {
 
     function initializeV2() external;
 
-    function initializeV3() external;
-
     function depositAssetsToEigenlayer(IERC20[] memory assets, uint256[] memory amounts, IStrategy[] memory strategies)
         external;
 
@@ -62,6 +60,8 @@ interface ITokenStakingNode {
     function withdrawn(IERC20 _token) external view returns (uint256);
     function maxMagnitudeByWithdrawalRoot(bytes32 _withdrawalRoot) external view returns (uint64);
     function withdrawableSharesByWithdrawalRoot(bytes32 _withdrawalRoot) external view returns (uint256);
+    function postSlashingUpgradeQueuedShares(IStrategy _strategy) external view returns (uint256);
+    function queuedAfterSlashingUpgrade(bytes32 _withdrawalRoot) external view returns (bool);
 
     /**
      * @notice Checks if the StakingNode's delegation state is synced with the DelegationManager.

--- a/src/ynEIGEN/TokenStakingNodesManager.sol
+++ b/src/ynEIGEN/TokenStakingNodesManager.sol
@@ -196,12 +196,6 @@ contract TokenStakingNodesManager is AccessControlUpgradeable, ITokenStakingNode
              emit NodeInitialized(address(node), initializedVersion);
          }
 
-         if (initializedVersion == 2) {
-             node.initializeV3();
-             initializedVersion = node.getInitializedVersion();
-             emit NodeInitialized(address(node), initializedVersion);
-         }
-
          // NOTE: for future versions add additional if clauses that initialize the node 
          // for the next version while keeping the previous initializers
     }

--- a/test/integration/ynEIGEN/TokenStakingNode.t.sol
+++ b/test/integration/ynEIGEN/TokenStakingNode.t.sol
@@ -88,7 +88,7 @@ contract NodeStateSnapshot {
             IStrategy strategy = state.eigenStrategyManager().strategies(asset);
 
             // Store queued shares for each strategy
-            snapshot.strategyQueuedShares[strategy] = node.queuedShares(strategy);
+            snapshot.strategyQueuedShares[strategy] = node.postSlashingUpgradeQueuedShares(strategy);
 
             // Store withdrawn amount for each token
             snapshot.withdrawnByToken[address(asset)] = node.withdrawn(asset);
@@ -590,7 +590,7 @@ contract TokenStakingNodeDelegate is ynEigenIntegrationBaseTest {
         // Get initial queued shares
         uint256[] memory initialQueuedShares = new uint256[](2);
         for (uint256 i = 0; i < strategies.length; i++) {
-            initialQueuedShares[i] = tokenStakingNodeInstance.queuedShares(strategies[i]);
+            initialQueuedShares[i] = tokenStakingNodeInstance.postSlashingUpgradeQueuedShares(strategies[i]);
         }
 
         // Undelegate
@@ -607,7 +607,7 @@ contract TokenStakingNodeDelegate is ynEigenIntegrationBaseTest {
 
         // Verify queued shares increased by the correct amount
         for (uint256 i = 0; i < strategies.length; i++) {
-            uint256 finalQueuedShares = tokenStakingNodeInstance.queuedShares(strategies[i]);
+            uint256 finalQueuedShares = tokenStakingNodeInstance.postSlashingUpgradeQueuedShares(strategies[i]);
             assertEq(
                 finalQueuedShares - initialQueuedShares[i],
                 initialShares[i],
@@ -681,7 +681,7 @@ contract TokenStakingNodeDelegate is ynEigenIntegrationBaseTest {
         uint256[] memory finalShares = delegationManager.getOperatorShares(operator2, strategies);
 
         for (uint256 i = 0; i < strategies.length; i++) {
-            finalShares[i] += tokenStakingNodeInstance.queuedShares(strategies[i]);
+            finalShares[i] += tokenStakingNodeInstance.postSlashingUpgradeQueuedShares(strategies[i]);
             assertEq(finalShares[i], initialShares[i], "Operator should have same shares");
         }
     }
@@ -735,7 +735,7 @@ contract TokenStakingNodeDelegate is ynEigenIntegrationBaseTest {
         // Get initial queued shares
         uint256[] memory initialQueuedShares = new uint256[](2);
         for (uint256 i = 0; i < strategies.length; i++) {
-            initialQueuedShares[i] = tokenStakingNodeInstance.queuedShares(strategies[i]);
+            initialQueuedShares[i] = tokenStakingNodeInstance.postSlashingUpgradeQueuedShares(strategies[i]);
         }
 
         // Undelegate
@@ -763,7 +763,7 @@ contract TokenStakingNodeDelegate is ynEigenIntegrationBaseTest {
 
         // Verify queued shares increased by the correct amount
         for (uint256 i = 0; i < strategies.length; i++) {
-            uint256 finalQueuedShares = tokenStakingNodeInstance.queuedShares(strategies[i]);
+            uint256 finalQueuedShares = tokenStakingNodeInstance.postSlashingUpgradeQueuedShares(strategies[i]);
             assertEq(
                 finalQueuedShares - initialQueuedShares[i],
                 initialShares[i],
@@ -796,7 +796,7 @@ contract TokenStakingNodeDelegate is ynEigenIntegrationBaseTest {
             {
                 // Verify queued shares decreased by the correct amount
                 for (uint256 i = 0; i < strategies.length; i++) {
-                    uint256 finalQueuedShares = tokenStakingNodeInstance.queuedShares(strategies[i]);
+                    uint256 finalQueuedShares = tokenStakingNodeInstance.postSlashingUpgradeQueuedShares(strategies[i]);
                     assertEq(finalQueuedShares, 0, "Queued shares should decrease to 0");
                 }
             }
@@ -947,7 +947,7 @@ contract TokenStakingNodeDelegate is ynEigenIntegrationBaseTest {
         // Get initial queued shares
         uint256[] memory initialQueuedShares = new uint256[](2);
         for (uint256 i = 0; i < strategies.length; i++) {
-            initialQueuedShares[i] = tokenStakingNodeInstance.queuedShares(strategies[i]);
+            initialQueuedShares[i] = tokenStakingNodeInstance.postSlashingUpgradeQueuedShares(strategies[i]);
         }
 
         // Create array of queued withdrawals based on strategies
@@ -976,7 +976,7 @@ contract TokenStakingNodeDelegate is ynEigenIntegrationBaseTest {
 
         // Verify queued shares increased by the correct amount
         for (uint256 i = 0; i < strategies.length; i++) {
-            uint256 finalQueuedShares = tokenStakingNodeInstance.queuedShares(strategies[i]);
+            uint256 finalQueuedShares = tokenStakingNodeInstance.postSlashingUpgradeQueuedShares(strategies[i]);
             assertEq(
                 finalQueuedShares - initialQueuedShares[i],
                 initialShares[i],
@@ -1004,7 +1004,7 @@ contract TokenStakingNodeDelegate is ynEigenIntegrationBaseTest {
             {
                 // Verify queued shares decreased by the correct amount
                 for (uint256 i = 0; i < strategies.length; i++) {
-                    uint256 finalQueuedShares = tokenStakingNodeInstance.queuedShares(strategies[i]);
+                    uint256 finalQueuedShares = tokenStakingNodeInstance.postSlashingUpgradeQueuedShares(strategies[i]);
                     assertEq(finalQueuedShares, 0, "Queued shares should decrease to 0");
                 }
             }
@@ -1076,7 +1076,7 @@ contract TokenStakingNodeDelegate is ynEigenIntegrationBaseTest {
         // Get initial queued shares
         uint256[] memory initialQueuedShares = new uint256[](3);
         for (uint256 i = 0; i < strategies.length; i++) {
-            initialQueuedShares[i] = tokenStakingNodeInstance.queuedShares(strategies[i]);
+            initialQueuedShares[i] = tokenStakingNodeInstance.postSlashingUpgradeQueuedShares(strategies[i]);
         }
 
         // Create array of queued withdrawals based on strategies
@@ -1108,7 +1108,7 @@ contract TokenStakingNodeDelegate is ynEigenIntegrationBaseTest {
 
         // Verify queued shares increased by the correct amount
         for (uint256 i = 0; i < strategies.length; i++) {
-            uint256 finalQueuedShares = tokenStakingNodeInstance.queuedShares(strategies[i]);
+            uint256 finalQueuedShares = tokenStakingNodeInstance.postSlashingUpgradeQueuedShares(strategies[i]);
             assertEq(
                 finalQueuedShares - initialQueuedShares[i],
                 initialShares[i],
@@ -1136,7 +1136,7 @@ contract TokenStakingNodeDelegate is ynEigenIntegrationBaseTest {
             {
                 // Verify queued shares decreased by the correct amount
                 for (uint256 i = 0; i < strategies.length; i++) {
-                    uint256 finalQueuedShares = tokenStakingNodeInstance.queuedShares(strategies[i]);
+                    uint256 finalQueuedShares = tokenStakingNodeInstance.postSlashingUpgradeQueuedShares(strategies[i]);
                     assertEq(finalQueuedShares, 0, "Queued shares should decrease to 0");
                 }
             }
@@ -1207,7 +1207,7 @@ contract TokenStakingNodeDelegate is ynEigenIntegrationBaseTest {
         // Get initial queued shares
         uint256[] memory initialQueuedShares = new uint256[](3);
         for (uint256 i = 0; i < strategies.length; i++) {
-            initialQueuedShares[i] = tokenStakingNodeInstance.queuedShares(strategies[i]);
+            initialQueuedShares[i] = tokenStakingNodeInstance.postSlashingUpgradeQueuedShares(strategies[i]);
         }
 
         // Create array of queued withdrawals based on strategies
@@ -1236,7 +1236,7 @@ contract TokenStakingNodeDelegate is ynEigenIntegrationBaseTest {
 
         // Verify queued shares increased by the correct amount
         for (uint256 i = 0; i < strategies.length; i++) {
-            uint256 finalQueuedShares = tokenStakingNodeInstance.queuedShares(strategies[i]);
+            uint256 finalQueuedShares = tokenStakingNodeInstance.postSlashingUpgradeQueuedShares(strategies[i]);
             assertEq(
                 finalQueuedShares - initialQueuedShares[i],
                 initialShares[i],
@@ -1264,7 +1264,7 @@ contract TokenStakingNodeDelegate is ynEigenIntegrationBaseTest {
             {
                 // Verify queued shares decreased by the correct amount
                 for (uint256 i = 0; i < strategies.length; i++) {
-                    uint256 finalQueuedShares = tokenStakingNodeInstance.queuedShares(strategies[i]);
+                    uint256 finalQueuedShares = tokenStakingNodeInstance.postSlashingUpgradeQueuedShares(strategies[i]);
                     assertEq(finalQueuedShares, 0, "Queued shares should decrease to 0");
                 }
             }
@@ -1476,7 +1476,7 @@ contract TokenStakingNodeSlashing is ynEigenIntegrationBaseTest {
     }
 
     function _queuedShares() private view returns (uint256) {
-        return tokenStakingNode.queuedShares(wstETHStrategy);
+        return tokenStakingNode.postSlashingUpgradeQueuedShares(wstETHStrategy);
     }
 
     function testQueuedSharesAreNotUpdatedIfSynchronizeIsNotCalled_FullSlashed() public {
@@ -1591,7 +1591,7 @@ contract TokenStakingNodeSlashing is ynEigenIntegrationBaseTest {
 
         bytes32 queuedWithdrawalRoot = _queueWithdrawal(depositShares);
 
-        assertEq(tokenStakingNode.queuedShares(wstETHStrategy), withdrawableShares, "Queued shares should be equal to withdrawable shares");
+        assertEq(tokenStakingNode.postSlashingUpgradeQueuedShares(wstETHStrategy), withdrawableShares, "Queued shares should be equal to withdrawable shares");
         assertEq(tokenStakingNode.maxMagnitudeByWithdrawalRoot(queuedWithdrawalRoot), 1 ether, "Max magnitude should be WAD");
         assertEq(tokenStakingNode.withdrawableSharesByWithdrawalRoot(queuedWithdrawalRoot), withdrawableShares, "Queued withdrawable shares for withdrawalshould be equal to withdrawable shares");
 
@@ -1599,7 +1599,7 @@ contract TokenStakingNodeSlashing is ynEigenIntegrationBaseTest {
 
         tokenStakingNode.synchronize();
 
-        assertEq(tokenStakingNode.queuedShares(wstETHStrategy), withdrawableShares / 2, "Queued shares should be half of the previous withdrawable shares");
+        assertEq(tokenStakingNode.postSlashingUpgradeQueuedShares(wstETHStrategy), withdrawableShares / 2, "Queued shares should be half of the previous withdrawable shares");
         assertEq(tokenStakingNode.maxMagnitudeByWithdrawalRoot(queuedWithdrawalRoot), 0.5 ether, "Max magnitude should be half of the previous withdrawable shares");
         assertEq(tokenStakingNode.withdrawableSharesByWithdrawalRoot(queuedWithdrawalRoot), withdrawableShares / 2, "Queued withdrawable shares for withdrawalshould be equal to half of the previous withdrawable shares");
     }
@@ -1613,7 +1613,7 @@ contract TokenStakingNodeSlashing is ynEigenIntegrationBaseTest {
         bytes32 queuedWithdrawalRoot2 = _queueWithdrawal(thirdOfDepositShares);
         bytes32 queuedWithdrawalRoot3 = _queueWithdrawal(thirdOfDepositShares);
 
-        assertApproxEqAbs(tokenStakingNode.queuedShares(wstETHStrategy), withdrawableShares, 2, "Queued shares should be equal to withdrawable shares");
+        assertApproxEqAbs(tokenStakingNode.postSlashingUpgradeQueuedShares(wstETHStrategy), withdrawableShares, 2, "Queued shares should be equal to withdrawable shares");
 
         assertEq(tokenStakingNode.maxMagnitudeByWithdrawalRoot(queuedWithdrawalRoot1), 1 ether, "Max magnitude for withdrawal 1 should be WAD");
         assertEq(tokenStakingNode.maxMagnitudeByWithdrawalRoot(queuedWithdrawalRoot2), 1 ether, "Max magnitude for withdrawal 2 should be WAD");
@@ -1627,7 +1627,7 @@ contract TokenStakingNodeSlashing is ynEigenIntegrationBaseTest {
 
         tokenStakingNode.synchronize();
 
-        assertApproxEqAbs(tokenStakingNode.queuedShares(wstETHStrategy), withdrawableShares / 2, 2, "Queued shares should be half of the previous withdrawable shares");
+        assertApproxEqAbs(tokenStakingNode.postSlashingUpgradeQueuedShares(wstETHStrategy), withdrawableShares / 2, 2, "Queued shares should be half of the previous withdrawable shares");
 
         assertEq(tokenStakingNode.maxMagnitudeByWithdrawalRoot(queuedWithdrawalRoot1), 0.5 ether, "Max magnitude for withdrawal 1 should be half of the previous withdrawable shares");
         assertEq(tokenStakingNode.maxMagnitudeByWithdrawalRoot(queuedWithdrawalRoot2), 0.5 ether, "Max magnitude for withdrawal 2 should be half of the previous withdrawable shares");
@@ -1647,7 +1647,7 @@ contract TokenStakingNodeSlashing is ynEigenIntegrationBaseTest {
         bytes32 queuedWithdrawalRoot2 = _queueWithdrawal(thirdOfDepositShares);
         bytes32 queuedWithdrawalRoot3 = _queueWithdrawal(thirdOfDepositShares);
 
-        assertApproxEqAbs(tokenStakingNode.queuedShares(wstETHStrategy), withdrawableShares, 2, "Queued shares should be equal to withdrawable shares");
+        assertApproxEqAbs(tokenStakingNode.postSlashingUpgradeQueuedShares(wstETHStrategy), withdrawableShares, 2, "Queued shares should be equal to withdrawable shares");
 
         assertEq(tokenStakingNode.maxMagnitudeByWithdrawalRoot(queuedWithdrawalRoot1), 1 ether, "Max magnitude for withdrawal 1 should be WAD");
         assertEq(tokenStakingNode.maxMagnitudeByWithdrawalRoot(queuedWithdrawalRoot2), 1 ether, "Max magnitude for withdrawal 2 should be WAD");
@@ -1659,7 +1659,7 @@ contract TokenStakingNodeSlashing is ynEigenIntegrationBaseTest {
 
         tokenStakingNode.synchronize();
 
-        assertApproxEqAbs(tokenStakingNode.queuedShares(wstETHStrategy), withdrawableShares, 2, "Queued shares should be equal to withdrawable shares");
+        assertApproxEqAbs(tokenStakingNode.postSlashingUpgradeQueuedShares(wstETHStrategy), withdrawableShares, 2, "Queued shares should be equal to withdrawable shares");
 
         assertEq(tokenStakingNode.maxMagnitudeByWithdrawalRoot(queuedWithdrawalRoot1), 1 ether, "Max magnitude for withdrawal 1 should be WAD");
         assertEq(tokenStakingNode.maxMagnitudeByWithdrawalRoot(queuedWithdrawalRoot2), 1 ether, "Max magnitude for withdrawal 2 should be WAD");
@@ -1692,7 +1692,7 @@ contract TokenStakingNodeSlashing is ynEigenIntegrationBaseTest {
         vm.prank(actors.ops.STAKING_NODES_WITHDRAWER);
         tokenStakingNode.completeQueuedWithdrawals(queuedWithdrawals, false);
 
-        assertEq(tokenStakingNode.queuedShares(wstETHStrategy), 0, "Queued shares should be 0");
+        assertEq(tokenStakingNode.postSlashingUpgradeQueuedShares(wstETHStrategy), 0, "Queued shares should be 0");
         assertEq(tokenStakingNode.maxMagnitudeByWithdrawalRoot(queuedWithdrawalRoot), 0, "Max magnitude should be 0");
         assertEq(tokenStakingNode.withdrawableSharesByWithdrawalRoot(queuedWithdrawalRoot), 0, "Queued withdrawable shares should be 0");
     }
@@ -1721,7 +1721,7 @@ contract TokenStakingNodeSlashing is ynEigenIntegrationBaseTest {
 
         bytes32 queuedWithdrawalRoot = _queueWithdrawal(depositShares);
 
-        assertEq(tokenStakingNode.queuedShares(wstETHStrategy), withdrawableShares, "Queued shares should be equal to withdrawable shares");
+        assertEq(tokenStakingNode.postSlashingUpgradeQueuedShares(wstETHStrategy), withdrawableShares, "Queued shares should be equal to withdrawable shares");
         assertEq(tokenStakingNode.withdrawableSharesByWithdrawalRoot(queuedWithdrawalRoot), withdrawableShares, "Withdrawable shares should be equal to withdrawable shares");
         assertEq(tokenStakingNode.maxMagnitudeByWithdrawalRoot(queuedWithdrawalRoot), 1 ether, "Max magnitude should be WAD");
 
@@ -1732,7 +1732,7 @@ contract TokenStakingNodeSlashing is ynEigenIntegrationBaseTest {
         vm.prank(actors.ops.STAKING_NODES_WITHDRAWER);
         tokenStakingNode.completeQueuedWithdrawals(queuedWithdrawals, false);
         
-        assertEq(tokenStakingNode.queuedShares(wstETHStrategy), 0, "Queued shares should be 0");
+        assertEq(tokenStakingNode.postSlashingUpgradeQueuedShares(wstETHStrategy), 0, "Queued shares should be 0");
         assertEq(tokenStakingNode.withdrawableSharesByWithdrawalRoot(queuedWithdrawalRoot), 0, "Withdrawable shares should be 0");
         assertEq(tokenStakingNode.maxMagnitudeByWithdrawalRoot(queuedWithdrawalRoot), 0, "Max magnitude should be 0");
     }

--- a/test/integration/ynEIGEN/WithdrawalsProcessor.t.sol
+++ b/test/integration/ynEIGEN/WithdrawalsProcessor.t.sol
@@ -174,7 +174,7 @@ contract WithdrawalsProcessorTest is ynEigenIntegrationBaseTest {
             vm.prank(keeper);
             withdrawalsProcessor.completeQueuedWithdrawals();
 
-            assertEq(tokenStakingNode.queuedShares(_stethStrategy), 0, "completeQueuedWithdrawals: E2");
+            assertEq(tokenStakingNode.postSlashingUpgradeQueuedShares(_stethStrategy), 0, "completeQueuedWithdrawals: E2");
             assertEq(withdrawalsProcessor.ids().completed, 1, "completeQueuedWithdrawals: E3");
         }
 
@@ -185,7 +185,7 @@ contract WithdrawalsProcessorTest is ynEigenIntegrationBaseTest {
             vm.prank(keeper);
             withdrawalsProcessor.completeQueuedWithdrawals();
 
-            assertEq(tokenStakingNode.queuedShares(_sfrxethStrategy), 0, "completeQueuedWithdrawals: E5");
+            assertEq(tokenStakingNode.postSlashingUpgradeQueuedShares(_sfrxethStrategy), 0, "completeQueuedWithdrawals: E5");
             assertEq(withdrawalsProcessor.ids().completed, 2, "completeQueuedWithdrawals: E6");
         }
 
@@ -197,7 +197,7 @@ contract WithdrawalsProcessorTest is ynEigenIntegrationBaseTest {
                 vm.prank(keeper);
                 withdrawalsProcessor.completeQueuedWithdrawals();
 
-                assertEq(tokenStakingNode.queuedShares(_oethStrategy), 0, "completeQueuedWithdrawals: E8");
+                assertEq(tokenStakingNode.postSlashingUpgradeQueuedShares(_oethStrategy), 0, "completeQueuedWithdrawals: E8");
                 assertEq(withdrawalsProcessor.ids().completed, 3, "completeQueuedWithdrawals: E9");
             }
         }
@@ -226,7 +226,7 @@ contract WithdrawalsProcessorTest is ynEigenIntegrationBaseTest {
             _queuedEverything = withdrawalsProcessor.queueWithdrawals(_asset, _nodes, _shares);
 
             assertFalse(_queuedEverything, "queueWithdrawal: E1");
-            assertEq(tokenStakingNode.queuedShares(_stethStrategy), _stethShares, "queueWithdrawal: E2");
+            assertEq(tokenStakingNode.postSlashingUpgradeQueuedShares(_stethStrategy), _stethShares, "queueWithdrawal: E2");
             assertEq(withdrawalsProcessor.batch(0), 1, "queueWithdrawal: E3");
 
             WithdrawalsProcessor.QueuedWithdrawal memory _queuedWithdrawal =
@@ -248,7 +248,7 @@ contract WithdrawalsProcessorTest is ynEigenIntegrationBaseTest {
             _queuedEverything = withdrawalsProcessor.queueWithdrawals(_asset, _nodes, _shares);
 
             assertTrue(_queuedEverything, "queueWithdrawal: E11");
-            assertEq(tokenStakingNode.queuedShares(_sfrxethStrategy), _sfrxethShares, "queueWithdrawal: E12");
+            assertEq(tokenStakingNode.postSlashingUpgradeQueuedShares(_sfrxethStrategy), _sfrxethShares, "queueWithdrawal: E12");
             assertEq(withdrawalsProcessor.batch(1), 2, "queueWithdrawal: E13");
 
             WithdrawalsProcessor.QueuedWithdrawal memory _queuedWithdrawal =
@@ -271,7 +271,7 @@ contract WithdrawalsProcessorTest is ynEigenIntegrationBaseTest {
                 _queuedEverything = withdrawalsProcessor.queueWithdrawals(_asset, _nodes, _shares);
 
                 assertFalse(_queuedEverything, "queueWithdrawal: E21");
-                assertEq(tokenStakingNode.queuedShares(_oethStrategy), _oethShares, "queueWithdrawal: E22");
+                assertEq(tokenStakingNode.postSlashingUpgradeQueuedShares(_oethStrategy), _oethShares, "queueWithdrawal: E22");
                 assertEq(withdrawalsProcessor.batch(2), 3, "queueWithdrawal: E23");
 
                 WithdrawalsProcessor.QueuedWithdrawal memory _queuedWithdrawal =

--- a/test/mocks/TestTokenStakingNodeV2.sol
+++ b/test/mocks/TestTokenStakingNodeV2.sol
@@ -12,7 +12,7 @@ contract TestTokenStakingNodeV2 is TokenStakingNode {
         uint valueToBeInitialized;
     }
 
-    function initializeV4(ReInit memory reInit) public reinitializer(4) {
+    function initializeV3(ReInit memory reInit) public reinitializer(4) {
         valueToBeInitialized = reInit.valueToBeInitialized;
     }
 

--- a/test/mocks/TestTokenStakingNodesManagerV2.sol
+++ b/test/mocks/TestTokenStakingNodesManagerV2.sol
@@ -30,16 +30,10 @@ contract TestTokenStakingNodesManagerV2 is TokenStakingNodesManager {
          }
 
          if (initializedVersion == 2) {
-             node.initializeV3();
-             initializedVersion = node.getInitializedVersion();
-             emit NodeInitialized(address(node), initializedVersion);
-         }
-
-         if (initializedVersion == 3) {
              TestTokenStakingNodeV2.ReInit memory reInit = TestTokenStakingNodeV2.ReInit({
                  valueToBeInitialized: 23
              });
-             TestTokenStakingNodeV2(payable(address(node))).initializeV4(reInit);
+             TestTokenStakingNodeV2(payable(address(node))).initializeV3(reInit);
              initializedVersion = node.getInitializedVersion();
              emit NodeInitialized(address(node), initializedVersion);
          }

--- a/test/scenarios/ynEIGEN/Delegation.t.sol
+++ b/test/scenarios/ynEIGEN/Delegation.t.sol
@@ -55,7 +55,7 @@ contract YnEigenDelegationScenarioTest is ynLSDeScenarioBaseTest {
 
         uint256[] memory queuedSharesBefore = new uint256[](strategies.length);
         for (uint256 i = 0; i < strategies.length; i++) {
-            queuedSharesBefore[i] = tokenStakingNode.queuedShares(strategies[i]);
+            queuedSharesBefore[i] = tokenStakingNode.postSlashingUpgradeQueuedShares(strategies[i]);
         }
 
         // Call undelegate from operator
@@ -84,7 +84,7 @@ contract YnEigenDelegationScenarioTest is ynLSDeScenarioBaseTest {
 
         for (uint256 i = 0; i < strategies.length; i++) {
             assertEq(
-                tokenStakingNode.queuedShares(strategies[i]) - queuedSharesBefore[i],
+                tokenStakingNode.postSlashingUpgradeQueuedShares(strategies[i]) - queuedSharesBefore[i],
                 shares[i],
                 "Queued shares should be equal to shares"
             );
@@ -120,7 +120,7 @@ contract YnEigenDelegationScenarioTest is ynLSDeScenarioBaseTest {
 
         for (uint256 i = 0; i < strategies.length; i++) {
             assertEq(
-                tokenStakingNode.queuedShares(strategies[i]),
+                tokenStakingNode.postSlashingUpgradeQueuedShares(strategies[i]),
                 queuedSharesBefore[i],
                 "Queued shares should be reinvested after completion of withdrawals"
             );

--- a/test/scenarios/ynEIGEN/WithdrawalsProcessor.t.sol
+++ b/test/scenarios/ynEIGEN/WithdrawalsProcessor.t.sol
@@ -245,7 +245,7 @@ contract WithdrawalsProcessorForkTest is ynLSDeScenarioBaseTest {
         for (uint256 i = 0; i < _assets.length; ++i) {
             for (uint256 j = 0; j < _nodes.length; ++j) {
                 if (_isHolesky() && _assets[i] == IERC20(chainAddresses.lsd.WOETH_ADDRESS)) continue;
-                if (_nodes[j].queuedShares(eigenStrategyManager.strategies(_assets[i])) > 0) return true;
+                if (_nodes[j].postSlashingUpgradeQueuedShares(eigenStrategyManager.strategies(_assets[i])) > 0) return true;
             }
         }
         return false;

--- a/test/scenarios/ynEIGEN/ynLSDeWithdrawals.t.sol
+++ b/test/scenarios/ynEIGEN/ynLSDeWithdrawals.t.sol
@@ -170,7 +170,7 @@ contract ynLSDeWithdrawalsTest is ynLSDeScenarioBaseTest {
         tokenStakingNode.queueWithdrawals(_strategy, _shares);
 
         assertEq(yneigen.totalAssets(), _totalAssetsBefore, "queueWithdrawalSTETH: E0");
-        assertEq(tokenStakingNode.queuedShares(_strategy), _shares, "queueWithdrawalSTETH: E1");
+        assertEq(tokenStakingNode.postSlashingUpgradeQueuedShares(_strategy), _shares, "queueWithdrawalSTETH: E1");
     }
 
     function _queueWithdrawalSFRXETH(uint256 _amount) internal {
@@ -185,7 +185,7 @@ contract ynLSDeWithdrawalsTest is ynLSDeScenarioBaseTest {
         tokenStakingNode.queueWithdrawals(_strategy, _shares);
 
         assertEq(yneigen.totalAssets(), _totalAssetsBefore, "queueWithdrawalSFRXETH: E0");
-        assertEq(tokenStakingNode.queuedShares(_strategy), _shares, "queueWithdrawalSFRXETH: E1");
+        assertEq(tokenStakingNode.postSlashingUpgradeQueuedShares(_strategy), _shares, "queueWithdrawalSFRXETH: E1");
     }
 
     function _queueWithdrawalOETH(uint256 _amount) internal {
@@ -200,7 +200,7 @@ contract ynLSDeWithdrawalsTest is ynLSDeScenarioBaseTest {
         tokenStakingNode.queueWithdrawals(_strategy, _shares);
 
         assertEq(yneigen.totalAssets(), _totalAssetsBefore, "queueWithdrawalOETH: E0");
-        assertEq(tokenStakingNode.queuedShares(_strategy), _shares, "queueWithdrawalOETH: E1");
+        assertEq(tokenStakingNode.postSlashingUpgradeQueuedShares(_strategy), _shares, "queueWithdrawalOETH: E1");
     }
 
     function _queueWithdrawalsWrongCaller() internal {
@@ -222,7 +222,7 @@ contract ynLSDeWithdrawalsTest is ynLSDeScenarioBaseTest {
         uint256 _nonce = delegationManager.cumulativeWithdrawalsQueued(address(tokenStakingNode)) - 1;
         uint32 _startBlock = uint32(block.number);
         IStrategy _strategy = IStrategy(chainAddresses.lsdStrategies.STETH_STRATEGY_ADDRESS);
-        uint256 _share = tokenStakingNode.queuedShares(_strategy);
+        uint256 _share = tokenStakingNode.postSlashingUpgradeQueuedShares(_strategy);
 
         IStrategy[] memory _strategies = new IStrategy[](1);
         _strategies[0] = _strategy;
@@ -246,7 +246,7 @@ contract ynLSDeWithdrawalsTest is ynLSDeScenarioBaseTest {
         tokenStakingNode.completeQueuedWithdrawals(withdrawal, true);
 
         assertApproxEqAbs(yneigen.totalAssets(), _totalAssetsBefore, 10, "completeQueuedWithdrawalsSTETH: E0");
-        assertEq(tokenStakingNode.queuedShares(_strategy), 0, "completeQueuedWithdrawalsSTETH: E1");
+        assertEq(tokenStakingNode.postSlashingUpgradeQueuedShares(_strategy), 0, "completeQueuedWithdrawalsSTETH: E1");
         assertApproxEqAbs(tokenStakingNode.withdrawn(IERC20(chainAddresses.lsd.WSTETH_ADDRESS)), _amount, 100, "completeQueuedWithdrawalsSTETH: E2");
     }
 
@@ -259,7 +259,7 @@ contract ynLSDeWithdrawalsTest is ynLSDeScenarioBaseTest {
         uint256 _nonce = delegationManager.cumulativeWithdrawalsQueued(address(tokenStakingNode)) - 1;
         uint32 _startBlock = uint32(block.number);
         IStrategy _strategy = IStrategy(chainAddresses.lsdStrategies.SFRXETH_STRATEGY_ADDRESS);
-        uint256 _share = tokenStakingNode.queuedShares(_strategy);
+        uint256 _share = tokenStakingNode.postSlashingUpgradeQueuedShares(_strategy);
 
         IStrategy[] memory _strategies = new IStrategy[](1);
         _strategies[0] = _strategy;
@@ -283,7 +283,7 @@ contract ynLSDeWithdrawalsTest is ynLSDeScenarioBaseTest {
         tokenStakingNode.completeQueuedWithdrawals(withdrawal, true);
 
         assertApproxEqAbs(yneigen.totalAssets(), _totalAssetsBefore, 10, "completeQueuedWithdrawalsSFRXETH: E0");
-        assertEq(tokenStakingNode.queuedShares(_strategy), 0, "completeQueuedWithdrawalsSFRXETH: E1");
+        assertEq(tokenStakingNode.postSlashingUpgradeQueuedShares(_strategy), 0, "completeQueuedWithdrawalsSFRXETH: E1");
         assertApproxEqAbs(tokenStakingNode.withdrawn(IERC20(chainAddresses.lsd.SFRXETH_ADDRESS)), _amount, 100, "completeQueuedWithdrawalsSFRXETH: E2");
     }
 
@@ -296,7 +296,7 @@ contract ynLSDeWithdrawalsTest is ynLSDeScenarioBaseTest {
         uint256 _nonce = delegationManager.cumulativeWithdrawalsQueued(address(tokenStakingNode)) - 1;
         uint32 _startBlock = uint32(block.number);
         IStrategy _strategy = IStrategy(chainAddresses.lsdStrategies.OETH_STRATEGY_ADDRESS);
-        uint256 _share = tokenStakingNode.queuedShares(_strategy);
+        uint256 _share = tokenStakingNode.postSlashingUpgradeQueuedShares(_strategy);
 
         IStrategy[] memory _strategies = new IStrategy[](1);
         _strategies[0] = _strategy;
@@ -319,7 +319,7 @@ contract ynLSDeWithdrawalsTest is ynLSDeScenarioBaseTest {
         tokenStakingNode.completeQueuedWithdrawals(withdrawal, true);
 
         assertApproxEqAbs(yneigen.totalAssets(), _totalAssetsBefore, 10, "completeQueuedWithdrawalsOETH: E0");
-        assertEq(tokenStakingNode.queuedShares(_strategy), 0, "completeQueuedWithdrawalsOETH: E1");
+        assertEq(tokenStakingNode.postSlashingUpgradeQueuedShares(_strategy), 0, "completeQueuedWithdrawalsOETH: E1");
         assertApproxEqAbs(tokenStakingNode.withdrawn(IERC20(chainAddresses.lsd.WOETH_ADDRESS)), _amount, 100, "completeQueuedWithdrawalsOETH: E2");
     }
 


### PR DESCRIPTION
Withdrawals queued after the upgrade will have their shares stored in `queuedAfterSlashingUpgrade`. 

Removes the need of having an [initializeV3](https://github.com/yieldnest/yieldnest-protocol/compare/fix/yn-eigen-queued-shares-post-slashing...fix/post-slashing-upgrade-queued-shares-variable?expand=1#diff-9fcb95777635d48a6c53628c1e091d4c0df5a2a6a5d8c4373189e482af00a515L146) function.

The variable queuedShares will contain only the pre slashing withdrawals and `getQueuedSharesAndWithdrawn`, which is the function used by the EigenStrategyManager to update balances, returns the sum of both new and old shares.



