### PR TITLE
fix: Use version 1.3.0 of eigen contracts

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -17,4 +17,4 @@
 [submodule "lib/eigenlayer-contracts"]
 	path = lib/eigenlayer-contracts
 	url = https://github.com/yieldnest/eigenlayer-contracts
-	branch = v1.1.1-v4.9.0
+	branch = v1.3.0-v4.9.0

--- a/script/delegation/DelegateTransactionDataBuilder.sol
+++ b/script/delegation/DelegateTransactionDataBuilder.sol
@@ -9,7 +9,7 @@ import {PooledDepositsVault} from "src/PooledDepositsVault.sol"; // Renamed from
 import {ActorAddresses} from "script/Actors.sol";
 import {console} from "lib/forge-std/src/console.sol";
 import {IStakingNode} from "src/interfaces/IStakingNode.sol";
-import {ISignatureUtils} from "lib/eigenlayer-contracts/src/contracts/interfaces/ISignatureUtils.sol";
+import {ISignatureUtilsMixinTypes} from "lib/eigenlayer-contracts/src/contracts/interfaces/ISignatureUtilsMixin.sol";
 import {IStakingNodesManager} from "src/interfaces/IStakingNodesManager.sol";
 import {ContractAddresses} from "script/ContractAddresses.sol";
 
@@ -52,7 +52,7 @@ contract DelegateTransactionBuilder is BaseScript {
             bytes memory delegateTxData = abi.encodeWithSelector(
                 IStakingNode.delegate.selector,
                 currentOperator,
-                ISignatureUtils.SignatureWithExpiry({signature: "", expiry: 0}),
+                ISignatureUtilsMixinTypes.SignatureWithExpiry({signature: "", expiry: 0}),
                 bytes32(0)
             );
             console.log("Node address:", stakingNodes[i]);

--- a/src/StakingNode.sol
+++ b/src/StakingNode.sol
@@ -9,7 +9,7 @@ import {IDelegationManager, IDelegationManagerTypes} from "lib/eigenlayer-contra
 import {IEigenPodManager} from "lib/eigenlayer-contracts/src/contracts/interfaces/IEigenPodManager.sol";
 import {IEigenPod} from "lib/eigenlayer-contracts/src/contracts/interfaces/IEigenPod.sol";
 import {IRewardsCoordinator} from "lib/eigenlayer-contracts/src/contracts/interfaces/IRewardsCoordinator.sol";
-import {ISignatureUtils} from "lib/eigenlayer-contracts/src/contracts/interfaces/ISignatureUtils.sol";
+import {ISignatureUtilsMixinTypes} from "lib/eigenlayer-contracts/src/contracts/interfaces/ISignatureUtilsMixin.sol";
 import {IStrategy} from "lib/eigenlayer-contracts/src/contracts/interfaces/IStrategy.sol";
 import {IBeacon} from "lib/openzeppelin-contracts/contracts/proxy/beacon/IBeacon.sol";
 import {IEigenPodManager} from "lib/eigenlayer-contracts/src/contracts/interfaces/IEigenPodManager.sol";
@@ -267,7 +267,7 @@ contract StakingNode is IStakingNode, StakingNodeEvents, ReentrancyGuardUpgradea
      */
     function delegate(
         address operator,
-        ISignatureUtils.SignatureWithExpiry memory approverSignatureAndExpiry,
+        ISignatureUtilsMixinTypes.SignatureWithExpiry memory approverSignatureAndExpiry,
         bytes32 approverSalt
     ) public override onlyDelegator onlyWhenSynchronized {
         IDelegationManager delegationManager = IDelegationManager(address(stakingNodesManager.delegationManager()));

--- a/src/interfaces/IStakingNode.sol
+++ b/src/interfaces/IStakingNode.sol
@@ -5,7 +5,7 @@ import {BeaconChainProofs} from "lib/eigenlayer-contracts/src/contracts/librarie
 import {IStakingNodesManager} from "src/interfaces/IStakingNodesManager.sol";
 import {IStrategy} from "lib/eigenlayer-contracts/src/contracts/interfaces/IStrategyManager.sol";
 import {IEigenPod} from "lib/eigenlayer-contracts/src/contracts/interfaces/IEigenPod.sol";
-import {ISignatureUtils} from "lib/eigenlayer-contracts/src/contracts/interfaces/ISignatureUtils.sol";
+import {ISignatureUtilsMixinTypes} from "lib/eigenlayer-contracts/src/contracts/interfaces/ISignatureUtilsMixin.sol";
 import {IDelegationManager} from "lib/eigenlayer-contracts/src/contracts/interfaces/IDelegationManager.sol";
 
 struct WithdrawalCompletionParams {
@@ -40,7 +40,7 @@ interface IStakingNode {
     function createEigenPod() external returns (IEigenPod);
     function delegate(
         address operator,
-        ISignatureUtils.SignatureWithExpiry memory approverSignatureAndExpiry,
+        ISignatureUtilsMixinTypes.SignatureWithExpiry memory approverSignatureAndExpiry,
         bytes32 approverSalt
     ) external;
     function undelegate() external returns (bytes32[] memory withdrawalRoots);

--- a/src/interfaces/ITokenStakingNode.sol
+++ b/src/interfaces/ITokenStakingNode.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.24;
 
 import {IERC20} from "lib/openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
-import {ISignatureUtils} from "lib/eigenlayer-contracts/src/contracts/interfaces/ISignatureUtils.sol";
+import {ISignatureUtilsMixinTypes} from "lib/eigenlayer-contracts/src/contracts/interfaces/ISignatureUtilsMixin.sol";
 import {ITokenStakingNodesManager} from "src/interfaces/ITokenStakingNodesManager.sol";
 import {IStrategy} from "lib/eigenlayer-contracts/src/contracts/interfaces/IStrategy.sol";
 import {IDelegationManager} from "lib/eigenlayer-contracts/src/contracts/interfaces/IDelegationManager.sol";
@@ -29,7 +29,7 @@ interface ITokenStakingNode {
 
     function getInitializedVersion() external view returns (uint64);
 
-    function delegate(address operator, ISignatureUtils.SignatureWithExpiry memory signature, bytes32 approverSalt)
+    function delegate(address operator, ISignatureUtilsMixinTypes.SignatureWithExpiry memory signature, bytes32 approverSalt)
         external;
 
     function undelegate() external returns (bytes32[] memory withdrawalRoots);

--- a/src/ynEIGEN/TokenStakingNode.sol
+++ b/src/ynEIGEN/TokenStakingNode.sol
@@ -9,7 +9,7 @@ import {IERC20} from "lib/openzeppelin-contracts/contracts/token/ERC20/IERC20.so
 import {IERC20 as IERC20V4} from "lib/eigenlayer-contracts/lib/openzeppelin-contracts-v4.9.0/contracts/interfaces/IERC20.sol";
 import {SafeERC20} from "lib/openzeppelin-contracts/contracts/token/ERC20/utils/SafeERC20.sol";
 import {ArrayLib} from "src/lib/ArrayLib.sol";
-import {ISignatureUtils} from "lib/eigenlayer-contracts/src/contracts/interfaces/ISignatureUtils.sol";
+import {ISignatureUtilsMixinTypes} from "lib/eigenlayer-contracts/src/contracts/interfaces/ISignatureUtilsMixin.sol";
 import {IStrategyManager} from "lib/eigenlayer-contracts/src/contracts/interfaces/IStrategyManager.sol";
 import {IDelegationManager, IDelegationManagerTypes} from "lib/eigenlayer-contracts/src/contracts/interfaces/IDelegationManager.sol";
 import {IStrategy} from "lib/eigenlayer-contracts/src/contracts/interfaces/IStrategy.sol";
@@ -311,7 +311,7 @@ contract TokenStakingNode is ITokenStakingNode, Initializable, ReentrancyGuardUp
      * @notice Delegates the staking operation to a specified operator.
      * @param operator The address of the operator to whom the staking operation is being delegated.
      */
-    function delegate(address operator, ISignatureUtils.SignatureWithExpiry memory signature, bytes32 approverSalt)
+    function delegate(address operator, ISignatureUtilsMixinTypes.SignatureWithExpiry memory signature, bytes32 approverSalt)
         public
         virtual
         onlyDelegator

--- a/test/integration/StakingNode.t.sol
+++ b/test/integration/StakingNode.t.sol
@@ -12,7 +12,7 @@ import {IEigenPod} from "lib/eigenlayer-contracts/src/contracts/interfaces/IEige
 import {IStrategyManager} from "lib/eigenlayer-contracts/src/contracts/interfaces/IStrategyManager.sol";
 import {StakingNode} from "src/StakingNode.sol";
 import {stdStorage, StdStorage} from "forge-std/Test.sol";
-import {ISignatureUtils} from "lib/eigenlayer-contracts/src/contracts/interfaces/ISignatureUtils.sol";
+import {ISignatureUtilsMixinTypes} from "lib/eigenlayer-contracts/src/contracts/interfaces/ISignatureUtilsMixin.sol";
 import {BytesLib} from "lib/eigenlayer-contracts/src/contracts/libraries/BytesLib.sol";
 import {EigenPod} from "lib/eigenlayer-contracts/src/contracts/pods/EigenPod.sol";
 import {EigenPodManager} from "lib/eigenlayer-contracts/src/contracts/pods/EigenPodManager.sol";
@@ -137,7 +137,7 @@ contract StakingNodeDelegation is StakingNodeTestBase {
     function testDelegateFailWhenNotAdmin() public {
         vm.expectRevert();
         stakingNodeInstance.delegate(
-            address(this), ISignatureUtils.SignatureWithExpiry({signature: "", expiry: 0}), bytes32(0)
+            address(this), ISignatureUtilsMixinTypes.SignatureWithExpiry({signature: "", expiry: 0}), bytes32(0)
         );
     }
 
@@ -149,7 +149,7 @@ contract StakingNodeDelegation is StakingNodeTestBase {
 
         vm.prank(actors.admin.STAKING_NODES_DELEGATOR);
         stakingNodeInstance.delegate(
-            operator1, ISignatureUtils.SignatureWithExpiry({signature: "", expiry: 0}), bytes32(0)
+            operator1, ISignatureUtilsMixinTypes.SignatureWithExpiry({signature: "", expiry: 0}), bytes32(0)
         );
 
         address delegatedOperator = delegationManager.delegatedTo(address(stakingNodeInstance));
@@ -166,7 +166,7 @@ contract StakingNodeDelegation is StakingNodeTestBase {
 
         vm.prank(actors.admin.STAKING_NODES_DELEGATOR);
         stakingNodeInstance.delegate(
-            operator1, ISignatureUtils.SignatureWithExpiry({signature: "", expiry: 0}), bytes32(0)
+            operator1, ISignatureUtilsMixinTypes.SignatureWithExpiry({signature: "", expiry: 0}), bytes32(0)
         );
 
         // // Attempt to undelegate with the wrong role
@@ -196,7 +196,7 @@ contract StakingNodeDelegation is StakingNodeTestBase {
 
         vm.prank(actors.admin.STAKING_NODES_DELEGATOR);
         stakingNodeInstance.delegate(
-            operator1, ISignatureUtils.SignatureWithExpiry({signature: "", expiry: 0}), bytes32(0)
+            operator1, ISignatureUtilsMixinTypes.SignatureWithExpiry({signature: "", expiry: 0}), bytes32(0)
         );
 
         // // Attempt to undelegate with the wrong role
@@ -232,7 +232,7 @@ contract StakingNodeDelegation is StakingNodeTestBase {
         vm.expectRevert();
         vm.prank(actors.admin.STAKING_NODES_DELEGATOR);
         stakingNodeInstance.delegate(
-            operator1, ISignatureUtils.SignatureWithExpiry({signature: "", expiry: 0}), bytes32(0)
+            operator1, ISignatureUtilsMixinTypes.SignatureWithExpiry({signature: "", expiry: 0}), bytes32(0)
         );
 
         vm.expectRevert();
@@ -258,7 +258,7 @@ contract StakingNodeDelegation is StakingNodeTestBase {
         // Delegate to operator1
         vm.prank(actors.admin.STAKING_NODES_DELEGATOR);
         stakingNodeInstance.delegate(
-            operator1, ISignatureUtils.SignatureWithExpiry({signature: "", expiry: 0}), bytes32(0)
+            operator1, ISignatureUtilsMixinTypes.SignatureWithExpiry({signature: "", expiry: 0}), bytes32(0)
         );
 
         address delegatedOperator1 = delegationManager.delegatedTo(address(stakingNodeInstance));
@@ -274,7 +274,7 @@ contract StakingNodeDelegation is StakingNodeTestBase {
         // Delegate to operator2
         vm.prank(actors.admin.STAKING_NODES_DELEGATOR);
         stakingNodeInstance.delegate(
-            operator2, ISignatureUtils.SignatureWithExpiry({signature: "", expiry: 0}), bytes32(0)
+            operator2, ISignatureUtilsMixinTypes.SignatureWithExpiry({signature: "", expiry: 0}), bytes32(0)
         );
 
         address delegatedOperator2 = delegationManager.delegatedTo(address(stakingNodeInstance));
@@ -298,7 +298,7 @@ contract StakingNodeDelegation is StakingNodeTestBase {
         // Delegate to operator1
         vm.prank(actors.admin.STAKING_NODES_DELEGATOR);
         stakingNodeInstance.delegate(
-            operator1, ISignatureUtils.SignatureWithExpiry({signature: "", expiry: 0}), bytes32(0)
+            operator1, ISignatureUtilsMixinTypes.SignatureWithExpiry({signature: "", expiry: 0}), bytes32(0)
         );
 
         address delegatedOperator1 = delegationManager.delegatedTo(address(stakingNodeInstance));
@@ -357,7 +357,7 @@ contract StakingNodeDelegation is StakingNodeTestBase {
         // Delegate to operator1
         vm.prank(actors.admin.STAKING_NODES_DELEGATOR);
         stakingNodeInstance.delegate(
-            operator1, ISignatureUtils.SignatureWithExpiry({signature: "", expiry: 0}), bytes32(0)
+            operator1, ISignatureUtilsMixinTypes.SignatureWithExpiry({signature: "", expiry: 0}), bytes32(0)
         );
 
         address delegatedOperator1 = delegationManager.delegatedTo(address(stakingNodeInstance));
@@ -458,7 +458,7 @@ contract StakingNodeDelegation is StakingNodeTestBase {
         // Delegate to operator1
         vm.prank(actors.admin.STAKING_NODES_DELEGATOR);
         stakingNodeInstance.delegate(
-            operator1, ISignatureUtils.SignatureWithExpiry({signature: "", expiry: 0}), bytes32(0)
+            operator1, ISignatureUtilsMixinTypes.SignatureWithExpiry({signature: "", expiry: 0}), bytes32(0)
         );
 
         address delegatedOperator1 = delegationManager.delegatedTo(address(stakingNodeInstance));
@@ -543,7 +543,7 @@ contract StakingNodeDelegation is StakingNodeTestBase {
 
         vm.prank(actors.admin.STAKING_NODES_DELEGATOR);
         stakingNodeInstance.delegate(
-            operator2, ISignatureUtils.SignatureWithExpiry({signature: "", expiry: 0}), bytes32(0)
+            operator2, ISignatureUtilsMixinTypes.SignatureWithExpiry({signature: "", expiry: 0}), bytes32(0)
         );
 
         delegatedAddress = delegationManager.delegatedTo(address(stakingNodeInstance));
@@ -574,7 +574,7 @@ contract StakingNodeDelegation is StakingNodeTestBase {
         // Delegate to operator1
         vm.prank(actors.admin.STAKING_NODES_DELEGATOR);
         stakingNodeInstance.delegate(
-            operator1, ISignatureUtils.SignatureWithExpiry({signature: "", expiry: 0}), bytes32(0)
+            operator1, ISignatureUtilsMixinTypes.SignatureWithExpiry({signature: "", expiry: 0}), bytes32(0)
         );
 
         address delegatedOperator1 = delegationManager.delegatedTo(address(stakingNodeInstance));
@@ -637,7 +637,7 @@ contract StakingNodeDelegation is StakingNodeTestBase {
 
         vm.prank(actors.admin.STAKING_NODES_DELEGATOR);
         stakingNodeInstance.delegate(
-            operator2, ISignatureUtils.SignatureWithExpiry({signature: "", expiry: 0}), bytes32(0)
+            operator2, ISignatureUtilsMixinTypes.SignatureWithExpiry({signature: "", expiry: 0}), bytes32(0)
         );
 
         delegatedAddress = delegationManager.delegatedTo(address(stakingNodeInstance));
@@ -691,7 +691,7 @@ contract StakingNodeDelegation is StakingNodeTestBase {
         // Delegate to operator2
         vm.prank(actors.admin.STAKING_NODES_DELEGATOR);
         stakingNodeInstance.delegate(
-            operator2, ISignatureUtils.SignatureWithExpiry({signature: "", expiry: 0}), bytes32(0)
+            operator2, ISignatureUtilsMixinTypes.SignatureWithExpiry({signature: "", expiry: 0}), bytes32(0)
         );
 
         // Verify total assets stayed the same after delegation to operator2
@@ -725,7 +725,7 @@ contract StakingNodeDelegation is StakingNodeTestBase {
         // Delegate to operator2
         vm.prank(actors.admin.STAKING_NODES_DELEGATOR);
         stakingNodeInstance.delegate(
-            operator2, ISignatureUtils.SignatureWithExpiry({signature: "", expiry: 0}), bytes32(0)
+            operator2, ISignatureUtilsMixinTypes.SignatureWithExpiry({signature: "", expiry: 0}), bytes32(0)
         );
 
         address delegatedOperator2 = delegationManager.delegatedTo(address(stakingNodeInstance));
@@ -766,7 +766,7 @@ contract StakingNodeDelegation is StakingNodeTestBase {
     function testSetClaimer() public {
         vm.prank(actors.admin.STAKING_NODES_DELEGATOR);
         stakingNodeInstance.delegate(
-            operator1, ISignatureUtils.SignatureWithExpiry({signature: "", expiry: 0}), bytes32(0)
+            operator1, ISignatureUtilsMixinTypes.SignatureWithExpiry({signature: "", expiry: 0}), bytes32(0)
         );
 
         // Create a claimer address

--- a/test/integration/StakingNode.t.sol
+++ b/test/integration/StakingNode.t.sol
@@ -1334,7 +1334,7 @@ contract StakingNodeWithdrawals is StakingNodeTestBase {
         for (uint256 i = 0; i < slashedValidatorCount; i++) {
             slashedValidators[i] = validatorIndices[i];
         }
-        beaconChain.slashValidators(slashedValidators);
+        beaconChain.slashValidators(slashedValidators, BeaconChainMock.SlashType.Minor);
 
         beaconChain.advanceEpoch_NoRewards();
 
@@ -1367,7 +1367,7 @@ contract StakingNodeWithdrawals is StakingNodeTestBase {
         // Capture final state
         StateSnapshot memory afterCompletion = takeSnapshot(nodeId);
 
-        uint256 slashedAmount = slashedValidatorCount * (beaconChain.SLASH_AMOUNT_GWEI() * 1e9);
+        uint256 slashedAmount = slashedValidatorCount * (beaconChain.MINOR_SLASH_AMOUNT_GWEI() * 1e9);
 
         // Assertions
         assertEq(
@@ -1425,7 +1425,7 @@ contract StakingNodeWithdrawals is StakingNodeTestBase {
         stakingNodeInstance.queueWithdrawals(withdrawalAmount);
 
         // Exit the validator
-        beaconChain.slashValidators(validatorIndices);
+        beaconChain.slashValidators(validatorIndices, BeaconChainMock.SlashType.Minor);
 
         beaconChain.advanceEpoch_NoRewards();
 
@@ -1433,7 +1433,7 @@ contract StakingNodeWithdrawals is StakingNodeTestBase {
         startAndVerifyCheckpoint(nodeId, validatorIndices);
 
         // Assert that podOwnerDepositShares are equal to negative slashingAmount
-        uint256 slashedAmount = beaconChain.SLASH_AMOUNT_GWEI() * 1e9;
+        uint256 slashedAmount = beaconChain.MINOR_SLASH_AMOUNT_GWEI() * 1e9;
         assertEq(
             eigenPodManager.podOwnerDepositShares(address(stakingNodeInstance)),
             -int256(slashedAmount),

--- a/test/integration/ynEIGEN/TokenStakingNode.t.sol
+++ b/test/integration/ynEIGEN/TokenStakingNode.t.sol
@@ -7,7 +7,7 @@ import {IStrategyManager} from "lib/eigenlayer-contracts/src/contracts/interface
 import {IynEigen} from "src/interfaces/IynEigen.sol";
 import {IPausable} from "lib/eigenlayer-contracts/src/contracts/interfaces/IPausable.sol";
 import {IDelegationManager, IDelegationManagerTypes} from "lib/eigenlayer-contracts/src/contracts/interfaces/IDelegationManager.sol";
-import {ISignatureUtils} from "lib/eigenlayer-contracts/src/contracts/interfaces/ISignatureUtils.sol";
+import {ISignatureUtilsMixinTypes} from "lib/eigenlayer-contracts/src/contracts/interfaces/ISignatureUtilsMixin.sol";
 import {TestAssetUtils} from "test/utils/TestAssetUtils.sol";
 import {stdStorage, StdStorage} from "forge-std/Test.sol";
 import {BytesLib} from "lib/eigenlayer-contracts/src/contracts/libraries/BytesLib.sol";
@@ -464,7 +464,7 @@ contract TokenStakingNodeDelegate is ynEigenIntegrationBaseTest {
     }
 
     function testTokenStakingNodeDelegate() public {
-        ISignatureUtils.SignatureWithExpiry memory signature;
+        ISignatureUtilsMixinTypes.SignatureWithExpiry memory signature;
         bytes32 approverSalt;
 
         vm.prank(actors.admin.STAKING_NODES_DELEGATOR);
@@ -477,7 +477,7 @@ contract TokenStakingNodeDelegate is ynEigenIntegrationBaseTest {
     }
 
     function testTokenStakingNodeUndelegate() public {
-        ISignatureUtils.SignatureWithExpiry memory signature;
+        ISignatureUtilsMixinTypes.SignatureWithExpiry memory signature;
         bytes32 approverSalt;
 
         vm.prank(actors.admin.STAKING_NODES_DELEGATOR);
@@ -513,7 +513,7 @@ contract TokenStakingNodeDelegate is ynEigenIntegrationBaseTest {
         // Delegate to operator1
         vm.prank(actors.admin.STAKING_NODES_DELEGATOR);
         tokenStakingNodeInstance.delegate(
-            operator1, ISignatureUtils.SignatureWithExpiry({signature: "", expiry: 0}), bytes32(0)
+            operator1, ISignatureUtilsMixinTypes.SignatureWithExpiry({signature: "", expiry: 0}), bytes32(0)
         );
 
         address delegatedOperator1 = delegationManager.delegatedTo(address(tokenStakingNodeInstance));
@@ -529,7 +529,7 @@ contract TokenStakingNodeDelegate is ynEigenIntegrationBaseTest {
         // Delegate to operator2
         vm.prank(actors.admin.STAKING_NODES_DELEGATOR);
         tokenStakingNodeInstance.delegate(
-            operator2, ISignatureUtils.SignatureWithExpiry({signature: "", expiry: 0}), bytes32(0)
+            operator2, ISignatureUtilsMixinTypes.SignatureWithExpiry({signature: "", expiry: 0}), bytes32(0)
         );
 
         address delegatedOperator2 = delegationManager.delegatedTo(address(tokenStakingNodeInstance));
@@ -562,7 +562,7 @@ contract TokenStakingNodeDelegate is ynEigenIntegrationBaseTest {
         assertEq(initialStrategyListLength, 2, "Initial strategy list length should be 2.");
 
         // Delegate to operator
-        ISignatureUtils.SignatureWithExpiry memory signature;
+        ISignatureUtilsMixinTypes.SignatureWithExpiry memory signature;
         bytes32 approverSalt;
         vm.prank(actors.admin.STAKING_NODES_DELEGATOR);
         tokenStakingNodeInstance.delegate(operator1, signature, approverSalt);
@@ -643,7 +643,7 @@ contract TokenStakingNodeDelegate is ynEigenIntegrationBaseTest {
         assertEq(initialStrategyListLength, 2, "Initial strategy list length should be 2.");
 
         // Delegate to operator
-        ISignatureUtils.SignatureWithExpiry memory signature;
+        ISignatureUtilsMixinTypes.SignatureWithExpiry memory signature;
         bytes32 approverSalt;
         vm.prank(actors.admin.STAKING_NODES_DELEGATOR);
         tokenStakingNodeInstance.delegate(operator1, signature, approverSalt);
@@ -710,7 +710,7 @@ contract TokenStakingNodeDelegate is ynEigenIntegrationBaseTest {
         assertEq(initialStrategyListLength, 2, "Initial strategy list length should be 2.");
 
         // Delegate to operator
-        ISignatureUtils.SignatureWithExpiry memory signature;
+        ISignatureUtilsMixinTypes.SignatureWithExpiry memory signature;
         bytes32 approverSalt;
         vm.prank(actors.admin.STAKING_NODES_DELEGATOR);
         tokenStakingNodeInstance.delegate(operator1, signature, approverSalt);
@@ -833,7 +833,7 @@ contract TokenStakingNodeDelegate is ynEigenIntegrationBaseTest {
     }
 
     function testOperatorUndelegateTokenStakingNode() public {
-        ISignatureUtils.SignatureWithExpiry memory signature;
+        ISignatureUtilsMixinTypes.SignatureWithExpiry memory signature;
         bytes32 approverSalt;
 
         vm.prank(actors.admin.STAKING_NODES_DELEGATOR);
@@ -925,7 +925,7 @@ contract TokenStakingNodeDelegate is ynEigenIntegrationBaseTest {
         assertEq(initialStrategyListLength, 2, "Initial strategy list length should be 2.");
 
         // Delegate to operator
-        ISignatureUtils.SignatureWithExpiry memory signature;
+        ISignatureUtilsMixinTypes.SignatureWithExpiry memory signature;
         bytes32 approverSalt;
         vm.prank(actors.admin.STAKING_NODES_DELEGATOR);
         tokenStakingNodeInstance.delegate(operator1, signature, approverSalt);
@@ -1057,7 +1057,7 @@ contract TokenStakingNodeDelegate is ynEigenIntegrationBaseTest {
         assertEq(initialStrategyListLength, 2, "Initial strategy list length should be 2.");
 
         // Delegate to operator
-        ISignatureUtils.SignatureWithExpiry memory signature;
+        ISignatureUtilsMixinTypes.SignatureWithExpiry memory signature;
         bytes32 approverSalt;
         vm.prank(actors.admin.STAKING_NODES_DELEGATOR);
         tokenStakingNodeInstance.delegate(operator1, signature, approverSalt);
@@ -1192,7 +1192,7 @@ contract TokenStakingNodeDelegate is ynEigenIntegrationBaseTest {
         assertEq(initialStrategyListLength, 2, "Initial strategy list length should be 2.");
 
         // Delegate to operator
-        ISignatureUtils.SignatureWithExpiry memory signature;
+        ISignatureUtilsMixinTypes.SignatureWithExpiry memory signature;
         bytes32 approverSalt;
         vm.prank(actors.admin.STAKING_NODES_DELEGATOR);
         tokenStakingNodeInstance.delegate(operator1, signature, approverSalt);

--- a/test/scenarios/fork/ynETH/WithdrawalsWithRewards-Scenario.t.sol
+++ b/test/scenarios/fork/ynETH/WithdrawalsWithRewards-Scenario.t.sol
@@ -575,7 +575,7 @@ contract M3WithdrawalsWithRewardsTest is WithdrawalsScenarioTestBase {
         uint256 withdrawnAmount = amount;
 
         // NOTE: This triggers the a exit of all validators
-        beaconChain.slashValidators(validatorIndices);
+        beaconChain.slashValidators(validatorIndices, BeaconChainMock.SlashType.Minor);
         beaconChain.advanceEpoch();
 
         // queue withdrawals
@@ -593,7 +593,7 @@ contract M3WithdrawalsWithRewardsTest is WithdrawalsScenarioTestBase {
         IEigenPod pod = stakingNodesManager.nodes(nodeId).eigenPod();
         uint64 withdrawableGwei = pod.withdrawableRestakedExecutionLayerGwei();
 
-        uint256 totalSlashAmount = beaconChain.SLASH_AMOUNT_GWEI() * state.validatorCount * 1e9;
+        uint256 totalSlashAmount = beaconChain.MINOR_SLASH_AMOUNT_GWEI() * state.validatorCount * 1e9;
         state.totalAssetsBefore = state.totalAssetsBefore + accumulatedRewards - totalSlashAmount;
         state.stakingNodeBalancesBefore[nodeId] = state.stakingNodeBalancesBefore[nodeId] + accumulatedRewards - totalSlashAmount;
         runSystemStateInvariants(state.totalAssetsBefore, state.totalSupplyBefore, state.stakingNodeBalancesBefore);
@@ -616,7 +616,7 @@ contract M3WithdrawalsWithRewardsTest is WithdrawalsScenarioTestBase {
         uint256 withdrawnAmount = amount;
 
         // NOTE: This triggers the a exit of all validators
-        beaconChain.slashValidators(validatorIndices);
+        beaconChain.slashValidators(validatorIndices, BeaconChainMock.SlashType.Minor);
         beaconChain.advanceEpoch();
 
         // queue withdrawals
@@ -630,7 +630,7 @@ contract M3WithdrawalsWithRewardsTest is WithdrawalsScenarioTestBase {
 
         startAndVerifyCheckpoint(nodeId, state);
 
-        uint256 totalSlashAmount = beaconChain.SLASH_AMOUNT_GWEI() * state.validatorCount * 1e9;
+        uint256 totalSlashAmount = beaconChain.MINOR_SLASH_AMOUNT_GWEI() * state.validatorCount * 1e9;
         state.totalAssetsBefore = state.totalAssetsBefore - totalSlashAmount;
         state.stakingNodeBalancesBefore[nodeId] = state.stakingNodeBalancesBefore[nodeId] - totalSlashAmount;
         runSystemStateInvariants(state.totalAssetsBefore, state.totalSupplyBefore, state.stakingNodeBalancesBefore);
@@ -685,12 +685,12 @@ contract M3WithdrawalsWithRewardsTest is WithdrawalsScenarioTestBase {
 
         // Trigger slashing of validators after withdrawals were queued
         // NOTE: This triggers the a exit of all validators
-        beaconChain.slashValidators(validatorIndices);
+        beaconChain.slashValidators(validatorIndices, BeaconChainMock.SlashType.Minor);
         beaconChain.advanceEpoch();
 
         startAndVerifyCheckpoint(nodeId, state);
 
-        uint256 totalSlashAmount = beaconChain.SLASH_AMOUNT_GWEI() * state.validatorCount * 1e9;
+        uint256 totalSlashAmount = beaconChain.MINOR_SLASH_AMOUNT_GWEI() * state.validatorCount * 1e9;
         state.totalAssetsBefore = state.totalAssetsBefore - totalSlashAmount;
         state.stakingNodeBalancesBefore[nodeId] = state.stakingNodeBalancesBefore[nodeId] - totalSlashAmount;
         runSystemStateInvariants(state.totalAssetsBefore, state.totalSupplyBefore, state.stakingNodeBalancesBefore);

--- a/test/scenarios/ynEIGEN/Delegation.t.sol
+++ b/test/scenarios/ynEIGEN/Delegation.t.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.24;
 
 import {IStrategy} from "lib/eigenlayer-contracts/src/contracts/interfaces/IStrategy.sol";
 import {IDelegationManagerTypes} from "lib/eigenlayer-contracts/src/contracts/interfaces/IDelegationManager.sol";
-import {ISignatureUtils} from "lib/eigenlayer-contracts/src/contracts/interfaces/ISignatureUtils.sol";
+import {ISignatureUtilsMixinTypes} from "lib/eigenlayer-contracts/src/contracts/interfaces/ISignatureUtilsMixin.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {TransparentUpgradeableProxy,ITransparentUpgradeableProxy} from "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
 import {UpgradeableBeacon} from "@openzeppelin/contracts/proxy/beacon/UpgradeableBeacon.sol";
@@ -36,7 +36,7 @@ contract YnEigenDelegationScenarioTest is ynLSDeScenarioBaseTest {
         tokenStakingNode = tokenStakingNodesManager.nodes(0);
 
         vm.prank(actors.admin.TOKEN_STAKING_NODES_DELEGATOR);
-        tokenStakingNode.delegate(actors.ops.TOKEN_STAKING_NODE_OPERATOR, ISignatureUtils.SignatureWithExpiry({signature: "", expiry: 0}), bytes32(0));
+        tokenStakingNode.delegate(actors.ops.TOKEN_STAKING_NODE_OPERATOR, ISignatureUtilsMixinTypes.SignatureWithExpiry({signature: "", expiry: 0}), bytes32(0));
     }
 
     function test_undelegate_Scenario_undelegateByOperator1() public {


### PR DESCRIPTION
Use version 1.3.0 of eigen contracts

They have not been deployed to holesky yet due to finalization issues so we should not merge this yet.