### PR TITLE
fix synchronize function in StakingNode

### DIFF
--- a/src/StakingNode.sol
+++ b/src/StakingNode.sol
@@ -317,9 +317,7 @@ contract StakingNode is IStakingNode, StakingNodeEvents, ReentrancyGuardUpgradea
 
         withdrawalRoots = delegationManager.undelegate(address(this));
 
-        syncQueuedShares();
-
-        delegatedTo = address(0);
+        synchronize();
 
         emit Undelegated(operator, int256(withdrawableShares[0]));
     }

--- a/src/StakingNode.sol
+++ b/src/StakingNode.sol
@@ -556,13 +556,12 @@ contract StakingNode is IStakingNode, StakingNodeEvents, ReentrancyGuardUpgradea
      * @notice Synchronizes the StakingNode's delegation state with the DelegationManager and queued shares.
      * @dev This function should be called after operator undelegate to this StakingNode or there is slashing event.
      */
-    function synchronize() public onlyDelegator {
+    function synchronize() public {
 
         syncQueuedShares();
 
         IDelegationManager delegationManager = stakingNodesManager.delegationManager();
         delegatedTo = delegationManager.delegatedTo(address(this));
-        stakingNodesManager.updateTotalETHStaked();
     }
 
     //--------------------------------------------------------------------------------------


### PR DESCRIPTION
suppose 2 stakingnodes are out of sync, we can't call synchronize anymore becuase it calls stakingNodesManager.updateTotalETHStaked();